### PR TITLE
修复液态mana的配方错误

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/ExtractorRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/ExtractorRecipePool.java
@@ -17,7 +17,7 @@ public class ExtractorRecipePool implements IRecipePool {
     @Override
     public void loadRecipes() {
 
-        final IRecipeMap Extractor = RecipeMaps.extractorRecipes;
+        final IRecipeMap Extractor = RecipeMaps.fluidExtractionRecipes;
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Config.combs.getStackForType(CombType.OTHERWORLDLY))


### PR DESCRIPTION
提取机实际上没有流体输出槽位！
修复前
![QQ截图20231220005520](https://github.com/Nxer/Twist-Space-Technology-Mod/assets/18422805/eac7c075-fc11-43ad-a060-8b2550b7171f)
修复后
![QQ截图20231220010556](https://github.com/Nxer/Twist-Space-Technology-Mod/assets/18422805/f2081d56-af4f-45ab-bfdb-94a8b0328d52)
