### PR TITLE
Use a preprocessor to help complete the creation of language files

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,81 @@
+tasks.register('preprocessLangInJavaFiles') {
+    group = 'preprocessing'
+    description = 'Preprocesses Java files.'
+
+    doLast {
+        // 获取main源集中的所有Java文件
+        def javaFiles = sourceSets.main.java
+
+        def langMap = [:]
+        def en_lang = [:]
+
+        langMap['en_US'] = en_lang
+        // 定义状态变量
+        def state = null
+        def trMatch = null
+
+        // 循环处理每个.java文件
+        javaFiles.each { file ->
+            // 读取文件内容
+            def content = file.text
+
+            // 按行处理内容
+            content.eachLine { line ->
+                // 根据状态处理行
+                switch (state) {
+                    case 'tr':
+                        // 如果上一行匹配了#tr模式
+                        def matcher = line =~ /\/\/\s*#([a-zA-Z_]{4})?\s(.*?)\s*/
+
+                        if (matcher) {
+                            // 处理匹配结果
+                            def groupCount = matcher.groupCount()
+                            // 如果匹配到一组或两组
+                            if (groupCount == 1 || groupCount == 2) {
+                                if (groupCount == 1) {
+                                    def key = trMatch.group(1) as String
+                                    def value = matcher.group(1)
+                                    en_lang[key] = value
+                                } else {
+                                    def lang = matcher.group(1)
+                                    def key = trMatch.group(1) as String
+                                    def value = matcher.group(2)
+                                    def lang1 = langMap[lang] as Map
+                                    if (lang1 == null) {
+                                        lang1 = [String: String]
+                                        langMap[lang] = lang1
+                                    }
+                                    lang1[key] = value
+                                }
+                            } else {
+                                // 处理其他情况，例如匹配到其他数量的组或者没有匹配
+                                trMatch = null
+                                state = null
+                            }
+                        }
+                        break
+                    default:
+                        // 检查是否匹配了#tr模式
+                        if (line =~ /\/\/\s*#tr\s+(.+?)\s*(.*?)?\s*/) {
+                            // 处理匹配结果
+                            def matcher = line =~ /\/\/\s*#tr\s+(.+?)\s*(.*?)?\s*/
+                            def groupCount = matcher.groupCount()
+
+                            // 如果匹配到一组或两组
+                            if (groupCount == 1) {
+                                state = 'tr'
+                                trMatch = matcher
+                            } else if (groupCount == 2) {
+                                def key = matcher.group(1)
+                                def value = matcher.group(2)
+                                en_lang[key] = value
+                            }
+                        }
+                        break
+                }
+            }
+        }
+        println "Found information: $langMap"
+    }
+}
+


### PR DESCRIPTION
使用一个预处理程序帮助制作Language文件，请允许我利用此项目测试它。
它会检查所有的源码文件，当出现`// #tr`结构时表示一个翻译条目的声明。一个翻译结构包含一个key，用于在I18n中获取该词条；至少一个value，原文。结构允许定义多个目标语言的翻译，在执行结束后会得到所有声明过的语言的lang文件，并且保持他们的key完全相同。部分缺失key的lang文件，将优先使用en_US.lang中的value替代，并添加后缀`(untranslated)`。若en_US.lang缺失key则采用其他lang文件中的value。

一个翻译结构的例子：
`anything // #tr demo.key Demo
`
代表en_US中的demo.key=Demo
另一个个翻译结构的例子：
```
// #tr demo.key
// #en_US Demo
// #zh_CN 演示
anything code
```
其中en_US可以省略变成：`// # Demo`

