### PR TITLE
change recipes of module hatches and machines

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/GTCMMachineRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/GTCMMachineRecipePool.java
@@ -2710,30 +2710,30 @@ public class GTCMMachineRecipePool implements IRecipePool {
                         ItemRefer.Compact_Fusion_Coil_T4.get(64),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt16, Materials.SuperconductorUMV, 64),
 
-                        StellarConstructionFrameMaterial.get(64),
+                        AnnihilationConstrainer.get(64),
                         SpaceWarper.get(64),
                         SpaceWarper.get(64),
-                        StellarConstructionFrameMaterial.get(64),
+                        AnnihilationConstrainer.get(64),
 
-                        // TODO Quantum Circuit
-                        QuantumCircuit.get(64),
+                        ItemList.Emitter_UMV.get(64),
                         ItemList.Field_Generator_UMV.get(64),
                         ItemList.Field_Generator_UMV.get(64),
-                        QuantumCircuit.get(64),
+                        ItemList.Emitter_UMV.get(64),
 
-                        ParticleTrapTimeSpaceShield.get(64),
+                        AdvancedHighPowerCoilBlock.get(64),
                         ItemList.ZPM6.get(64),
                         GravitationalLens.get(64),
-                        AnnihilationConstrainer.get(64)
+                        AdvancedHighPowerCoilBlock.get(64)
                     )
                     .fluidInputs(
-                        MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(20_000_000),
-                        MaterialsUEVplus.Eternity.getMolten(144 * 131072),
-                        MyMaterial.shirabon.getMolten(144 * 524288)
+                        MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2_000_000_000),
+                        MaterialsUEVplus.Eternity.getMolten(144 * 524288),
+                        MyMaterial.shirabon.getMolten(144 * 524288),
+                        MaterialsUEVplus.SpaceTime.getMolten(144 * 2097152)
                     )
                     .itemOutputs(GTCMItemList.DimensionallyTranscendentMatterPlasmaForgePrototypeMK2.get(1))
                     .eut(RECIPE_UXV)
-                    .duration(20 * 3600 * 8)
+                    .duration(20 * 3600 * 24)
                     .addTo(assemblyLine);
             }
 
@@ -2743,8 +2743,8 @@ public class GTCMMachineRecipePool implements IRecipePool {
                     .itemInputs(
                         copyAmount(64, Loaders.NA),
                         HiC_T5.get(64),
-                        ItemRefer.Compact_Fusion_Coil_T4.get(64),
-                        new Object[]{OrePrefixes.circuit.get(Materials.Optical), 64}
+                        ItemRefer.Compact_Fusion_Coil_T3.get(8),
+                        new Object[]{OrePrefixes.circuit.get(Materials.Optical), 8}
                     )
                     .fluidInputs(
                         ALLOY.BLACK_TITANIUM.getFluidStack(144 * 514),
@@ -2754,7 +2754,7 @@ public class GTCMMachineRecipePool implements IRecipePool {
                     .itemOutputs(GTCMItemList.LargeNeutronOscillator.get(1))
                     .specialValue(3)
                     .eut(RECIPE_UEV)
-                    .duration(20 * 3600)
+                    .duration(20 * 600)
                     .addTo(GoodGeneratorRecipeMaps.preciseAssemblerRecipes);
             }
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/ModularHatchesRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/ModularHatchesRecipePool.java
@@ -102,14 +102,14 @@ public class ModularHatchesRecipePool implements IRecipePool {
                 .metadata(RESEARCH_TIME, 24 * HOURS)
                 .itemInputs(
                     CustomItemList.Hull_UIV.get(1),
-                    ItemList.Electric_Motor_UIV.get(24),
-                    ItemList.Conveyor_Module_UIV.get(16),
-                    ItemList.Robot_Arm_UIV.get(32),
+                    ItemList.Electric_Motor_UIV.get(16),
+                    ItemList.Conveyor_Module_UIV.get(12),
+                    ItemList.Robot_Arm_UIV.get(18),
 
                     ItemList.Electric_Pump_UIV.get(12),
-                    ItemList.Field_Generator_UIV.get(3),
-                    ItemList.Sensor_UIV.get(3),
-                    new Object[] { OrePrefixes.circuit.get(Materials.Optical), 16 },
+                    ItemList.Field_Generator_UIV.get(1),
+                    ItemList.Sensor_UIV.get(1),
+                    new Object[] { OrePrefixes.circuit.get(Materials.Optical), 2 },
 
                     CustomItemList.HighEnergyFlowCircuit.get(36),
                     GT_OreDictUnificator.get(OrePrefixes.wireGt16, Materials.Infinity, 18),
@@ -119,13 +119,13 @@ public class ModularHatchesRecipePool implements IRecipePool {
                     GT_OreDictUnificator.get(OrePrefixes.screw, MaterialsUEVplus.TranscendentMetal, 32),
                     GT_OreDictUnificator.get(OrePrefixes.plate, MaterialsUEVplus.TranscendentMetal, 64))
                 .fluidInputs(
-                    ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(144 * 64 * 16),
-                    Materials.Infinity.getMolten(144 * 64 * 16),
-                    Materials.Quantium.getMolten(144 * 64 * 64),
+                    ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(144 * 64),
+                    Materials.Infinity.getMolten(144 * 64),
+                    Materials.Quantium.getMolten(144 * 64 * 16),
                     MISC_MATERIALS.MUTATED_LIVING_SOLDER.getFluidStack(144 * 128))
                 .itemOutputs(GTCMItemList.ExecutionCore.get(1))
                 .eut(RECIPE_UIV)
-                .duration(20 * 600)
+                .duration(20 * 120)
                 .addTo(AssemblyLine);
 
             // Advanced Execution Core
@@ -229,13 +229,18 @@ public class ModularHatchesRecipePool implements IRecipePool {
                 .itemInputs(
                     GTCMItemList.LowSpeedPerfectOverclockController.get(1),
                     GT_OreDictUnificator.get(OrePrefixes.frameGt, MaterialsUEVplus.SpaceTime, 16),
-                    ItemList.Field_Generator_UMV.get(64),
-                    ItemList.Emitter_UMV.get(64),
+                    ItemRefer.Compact_Fusion_Coil_T4.get(64),
+                    Materials.Gold.getNanite(64),
 
-                    ItemRefer.Compact_Fusion_Coil_T4.get(64),
-                    ItemRefer.Compact_Fusion_Coil_T4.get(64),
-                    Materials.Gold.getNanite(64),
-                    Materials.Gold.getNanite(64),
+                    ItemList.Field_Generator_UMV.get(64),
+                    ItemList.Field_Generator_UMV.get(64),
+                    ItemList.Field_Generator_UMV.get(64),
+                    ItemList.Field_Generator_UMV.get(64),
+
+                    ItemList.Emitter_UMV.get(64),
+                    ItemList.Emitter_UMV.get(64),
+                    ItemList.Emitter_UMV.get(64),
+                    ItemList.Emitter_UMV.get(64),
 
                     new Object[] { OrePrefixes.circuit.get(Materials.Quantum), 64 },
                     MyMaterial.metastableOganesson.get(OrePrefixes.plateDense, 64),
@@ -347,10 +352,10 @@ public class ModularHatchesRecipePool implements IRecipePool {
                         copyAmount(64, circuits[i]),
 
                         copyAmount(64, fieldGenerators[i]),
-                        copyAmount(64, motors[i]),
-                        copyAmount(64, motors[i]),
+                        copyAmount(64, fieldGenerators[i]),
+                        copyAmount(64, fieldGenerators[i]),
 
-                        copyAmount(64, pistons[i]),
+                        copyAmount(64, motors[i]),
                         copyAmount(64, pistons[i]),
                         GT_OreDictUnificator.get(OrePrefixes.plate, materials[i], 64))
                     .fluidInputs(materials[i].getMolten(144 * 64))


### PR DESCRIPTION
 - 降低普通执行核心模块造价 Buff normal execution core recipe -> cheaper
 - 降低大型中子振荡器的造价 Buff Large Neutron Oscillator recipe -> cheaper
 - 提高超维度物质等离子锻炉原型机MK2的造价 Nerf DTPF prototype MK2 recipe -> more expensive
 - 提高速度控制模块的造价 Nerf Speed Controller Module recipe -> more expensive
 - 提高无损超频控制模块的造价 Nerf Perfect Overclock Controller Module recipe -> more expensive