### PR TITLE
update

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,7 +49,7 @@ dependencies {
 //    implementation('com.github.GTNewHorizons:Railcraft:9.15.8:dev')
     implementation('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     implementation('com.github.GTNewHorizons:ThaumicEnergistics:1.6.11-GTNH-pre:dev')
-//    implementation('com.github.GTNewHorizons:ThaumicBases:1.7.3:dev')
+//    implementation('com.github.GTNewHorizons:ThaumicBases:1.7.4:dev')
 //    implementation('curse.maven:automagy-222153:2285272')
 //    implementation('com.github.GTNewHorizons:ThaumicHorizons:1.6.1:dev')
 //    implementation('com.github.GTNewHorizons:Gadomancy:1.3.2:dev')


### PR DESCRIPTION
new Thaumic Base version will use dummy core 1.19.0
pre tags will cause a fail on buildscript runs