### PR TITLE
尝试修复工业注魔矩阵自动搭建的守卫者方块无法拆除的问题

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -2928,7 +2928,6 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
                 ((TileOwned) tileEntity).owner = getPlayName();
                 return true;
             }
-            return false;
         }
         return false;
     }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -2924,13 +2924,11 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
 
     public final boolean addCosmeticOpaque(TileEntity tileEntity) {
         if (tileEntity instanceof TileOwned) {
-            if (getPlayName() == null) {
-                return false;
-            }
-            if (Objects.equals(((TileOwned) tileEntity).owner, "")) {
+            if (getPlayName() != null && Objects.equals(((TileOwned) tileEntity).owner, "")) {
                 ((TileOwned) tileEntity).owner = getPlayName();
+                return true;
             }
-            return true;
+            return false;
         }
         return false;
     }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -64,6 +64,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.InfusionRecipe;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.common.tiles.TileNodeEnergized;
+import thaumcraft.common.tiles.TileOwned;
 import thaumicenergistics.common.storage.EnumEssentiaStorageTypes;
 import thaumicenergistics.common.tiles.TileInfusionProvider;
 
@@ -2903,7 +2904,8 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
                     ofChain(
                         ofTileAdder(GT_TileEntity_IndustrialMagicMatrix::addNodeEnergized, Blocks.air, 0),
                         ofBlock(Blocks.air, 0)))
-                .addElement('Z', ofBlock(blockCosmeticOpaque, 2))
+                .addElement('Z', ofChain(ofTileAdder(GT_TileEntity_IndustrialMagicMatrix::addCosmeticOpaque,blockCosmeticOpaque,2),
+                        ofBlock(blockCosmeticOpaque,2)))
                 .addElement('0', ofBlock(blockStoneDevice, 2))
                 .addElement('1', ofFrame(Materials.Thaumium))
                 .addElement('3', ofBlock(blockStoneDevice, 10))
@@ -2914,6 +2916,17 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
                 .build();
         }
         return STRUCTURE_DEFINITION;
+    }
+
+    public final boolean addCosmeticOpaque(TileEntity tileEntity){
+        if (tileEntity instanceof TileOwned){
+            if (getPlayName() == null) {
+                return false;
+            }
+             ((TileOwned) tileEntity).owner = getPlayName();
+            return true;
+        }
+        return false;
     }
 
     public final boolean addInfusionProvider(TileEntity aTileEntity) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -15,6 +15,7 @@ import static thaumcraft.common.lib.research.ResearchManager.getResearchForPlaye
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -2926,7 +2927,9 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
             if (getPlayName() == null) {
                 return false;
             }
-            ((TileOwned) tileEntity).owner = getPlayName();
+            if (Objects.equals(((TileOwned) tileEntity).owner, "")) {
+                ((TileOwned) tileEntity).owner = getPlayName();
+            }
             return true;
         }
         return false;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -2904,8 +2904,11 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
                     ofChain(
                         ofTileAdder(GT_TileEntity_IndustrialMagicMatrix::addNodeEnergized, Blocks.air, 0),
                         ofBlock(Blocks.air, 0)))
-                .addElement('Z', ofChain(ofTileAdder(GT_TileEntity_IndustrialMagicMatrix::addCosmeticOpaque,blockCosmeticOpaque,2),
-                        ofBlock(blockCosmeticOpaque,2)))
+                .addElement(
+                    'Z',
+                    ofChain(
+                        ofTileAdder(GT_TileEntity_IndustrialMagicMatrix::addCosmeticOpaque, blockCosmeticOpaque, 2),
+                        ofBlock(blockCosmeticOpaque, 2)))
                 .addElement('0', ofBlock(blockStoneDevice, 2))
                 .addElement('1', ofFrame(Materials.Thaumium))
                 .addElement('3', ofBlock(blockStoneDevice, 10))
@@ -2918,12 +2921,12 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
         return STRUCTURE_DEFINITION;
     }
 
-    public final boolean addCosmeticOpaque(TileEntity tileEntity){
-        if (tileEntity instanceof TileOwned){
+    public final boolean addCosmeticOpaque(TileEntity tileEntity) {
+        if (tileEntity instanceof TileOwned) {
             if (getPlayName() == null) {
                 return false;
             }
-             ((TileOwned) tileEntity).owner = getPlayName();
+            ((TileOwned) tileEntity).owner = getPlayName();
             return true;
         }
         return false;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -2926,8 +2926,8 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
         if (tileEntity instanceof TileOwned) {
             if (getPlayName() != null && Objects.equals(((TileOwned) tileEntity).owner, "")) {
                 ((TileOwned) tileEntity).owner = getPlayName();
-                return true;
             }
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
现在成型后会自动将守卫者玻璃用于识别放置者的NBT改为机器拥有者