### PR TITLE
Cosmic processer producing rebalance

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/multiMachineClasses/processingLogics/GTCM_ParallelHelper.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/multiMachineClasses/processingLogics/GTCM_ParallelHelper.java
@@ -570,6 +570,7 @@ public class GTCM_ParallelHelper extends GT_ParallelHelper {
                 // parameter of this item final amount
                 long outputs = (long) currentParallel * origin.stackSize * outputChance / 10000;
                 long remain = (long) currentParallel * origin.stackSize * outputChance % 10000;
+                // TODO add switch of remain > 0
                 if (remain > XSTR.XSTR_INSTANCE.nextInt(10000)) {
                     outputs += origin.stackSize;
                 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
@@ -367,23 +367,23 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
         TST_RecipeBuilder.builder()
             .itemInputs(
                 GT_Utility.getIntegratedCircuit(1),
-                SeedsSpaceTime.get(2),
+                SeedsSpaceTime.get(3),
                 Circuit_CosmicComputer.get(2),
                 EnergyFluctuationSelfHarmonizer.get(1),
-                InformationHorizonInterventionShell.get(2),
-                PacketInformationTranslationArray.get(8),
-                SpaceTimeSuperconductingInlaidMotherboard.get(2),
-                CELESTIAL_TUNGSTEN.getPlate(8))
+                InformationHorizonInterventionShell.get(3),
+                PacketInformationTranslationArray.get(9),
+                SpaceTimeSuperconductingInlaidMotherboard.get(3),
+                CELESTIAL_TUNGSTEN.getPlate(9))
             .fluidInputs(
                 // TODO spacetime glue
                 Materials.Hydrogen.getPlasma(1000),
-                MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(576),
+                MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(72),
                 MaterialsUEVplus.Space.getMolten(1152),
                 MaterialsUEVplus.Time.getMolten(1152))
-            .itemOutputs(ItemList.Circuit_CosmicMainframe.get(2), ItemList.Tesseract.get(4))
+            .itemOutputs(ItemList.Circuit_CosmicMainframe.get(3), ItemList.Tesseract.get(6))
             .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(666))
             .eut(RECIPE_UMV)
-            .duration(20 * 1500)
+            .duration(20 * 2400)
             .addTo(GTCMRecipe.MiracleTopRecipes);
 
         // Seed of Space and Time

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
@@ -11,6 +11,7 @@ import static com.Nxer.TwistSpaceTechnology.util.Utils.setStackSize;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UEV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UIV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UMV;
+import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UXV;
 import static com.dreammaster.gthandler.GT_CoreModSupport.RadoxPolymer;
 import static gregtech.api.enums.ItemList.Circuit_CosmicAssembly;
 import static gregtech.api.enums.ItemList.Circuit_CosmicComputer;
@@ -458,7 +459,7 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
             .itemInputs(Laser_Lens_Special.get(1), eternal_singularity.copy())
             .itemOutputs(MaterialType.Singularity.stack(16), MaterialType.Singularity.stack(16))
             .outputChances(5000, 5000)
-            .eut(RECIPE_UMV)
+            .eut(RECIPE_UXV)
             .duration(20 * 100)
             .addTo(BartWorksRecipeMaps.electricImplosionCompressorRecipes);
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
@@ -474,7 +474,7 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
                 MaterialsUEVplus.Space.getMolten(144),
                 MaterialsUEVplus.Time.getMolten(144),
                 MaterialsUEVplus.SpaceTime.getMolten(144 * 2))
-                .itemOutputs(GTCMItemList.ParticleTrapTimeSpaceShield.get(64))
+            .itemOutputs(GTCMItemList.ParticleTrapTimeSpaceShield.get(64))
             .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2500))
             .eut(TierEU.RECIPE_UMV)
             .duration(20 * 64)

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
@@ -280,8 +280,8 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
             .fluidInputs(
                 // TODO spacetime glue
                 Materials.Hydrogen.getPlasma(100),
-                Materials.Lead.getPlasma(36),
-                MyMaterial.metastableOganesson.getMolten(144),
+                Materials.Lead.getPlasma(72),
+                Materials.Plutonium241.getPlasma(72),
                 RadoxPolymer.getMolten(288))
             .itemOutputs(
                 Circuit_CosmicProcessor.get(1),
@@ -304,8 +304,8 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
             .fluidInputs(
                 // TODO spacetime glue
                 Materials.Hydrogen.getPlasma(200),
-                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(144),
-                MyMaterial.metastableOganesson.getMolten(288),
+                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(72),
+                MyMaterial.metastableOganesson.getMolten(144),
                 RadoxPolymer.getMolten(288))
             .itemOutputs(
                 ItemList.Circuit_CosmicAssembly.get(1),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/CosmicProcessorCircuitRecipePool.java
@@ -20,6 +20,7 @@ import static gregtech.api.util.GT_RecipeConstants.RESEARCH_ITEM;
 import static gregtech.api.util.GT_RecipeConstants.RESEARCH_TIME;
 import static gtPlusPlus.core.material.ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN;
 import static gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList.Laser_Lens_Special;
+import static gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList.SpaceTimeBendingCore;
 
 import net.minecraft.item.ItemStack;
 
@@ -38,6 +39,7 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -459,6 +461,23 @@ public class CosmicProcessorCircuitRecipePool implements IRecipePool {
             .eut(RECIPE_UMV)
             .duration(20 * 100)
             .addTo(BartWorksRecipeMaps.electricImplosionCompressorRecipes);
+
+        // ParticleTrapTimeSpaceShield advanced recipe
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_Utility.getIntegratedCircuit(21),
+                SpaceTimeBendingCore.get(0),
+                SpaceTimeSuperconductingInlaidMotherboard.get(1),
+                Materials.Glowstone.getNanite(16))
+            .fluidInputs(
+                MaterialsUEVplus.Space.getMolten(144),
+                MaterialsUEVplus.Time.getMolten(144),
+                MaterialsUEVplus.SpaceTime.getMolten(144 * 2))
+                .itemOutputs(GTCMItemList.ParticleTrapTimeSpaceShield.get(64))
+            .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2500))
+            .eut(TierEU.RECIPE_UMV)
+            .duration(20 * 64)
+            .addTo(GTCMRecipe.MiracleTopRecipes);
 
     }
 }


### PR DESCRIPTION
 - Decrease Magneto Constrained Star Matter consumption of UXV Cosmic Mainframe.
 - Increase UXV Cosmic Mainframe output amount of adv recipe.
 - Add recipe to produce AE Singularity.
 - Adjust UEV UIV recipe of Cosmic Circuit.
 - Add advanced recipe of Particle Trap - SpaceTime Shield.