### PR TITLE
"Don't Use Wildcard.", he said.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,8 @@ indent_size = 2
 
 [*.lang]
 trim_trailing_whitespace = false
+
+[*.java]
+# to prevent imports merge into a asterisk(*)
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999


### PR DESCRIPTION
So there is 2 more rules in `.editorconfig` to prevent you from using wildcard imports.