### PR TITLE
修复微型时空发生装置狂刷日志问题

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_MicroSpaceTimeFabricatorio.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_MicroSpaceTimeFabricatorio.java
@@ -250,7 +250,7 @@ public class TST_MicroSpaceTimeFabricatorio extends GTCM_MultiMachineBase<TST_Mi
         if (block == StabilisationFieldGenerators && meta <= 8) {
             return meta + 2;
         }
-        return 0;
+        return -1;
     }
 
     public static int getBlockTranscendentCasingTier(Block block, int meta) {


### PR DESCRIPTION
打开这东西的NEI能卡10秒以上，启动器发现大量垃圾日志。
把getBlockFieldTier缺省值改成-1以避免输出垃圾。