### PR TITLE
Fix 270 problems

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/AssemblyLineWithoutResearchRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/AssemblyLineWithoutResearchRecipePool.java
@@ -16,6 +16,8 @@ import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.SuperSolarPanels;
 import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.MINUTES;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gtPlusPlus.core.material.MaterialMisc.MUTATED_LIVING_SOLDER;
 import static tectech.loader.recipe.BaseRecipeLoader.getItemContainer;
 import static tectech.thing.CustomItemList.EOH_Reinforced_Spatial_Casing;
@@ -140,9 +142,13 @@ public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
             StabilisationFieldGeneratorTier5.get(1), StabilisationFieldGeneratorTier6.get(1),
             StabilisationFieldGeneratorTier7.get(1), StabilisationFieldGeneratorTier8.get(1),
             ItemList.Hatch_Energy_LuV.get(1), ItemList.Hatch_Energy_ZPM.get(1), ItemList.Hatch_Energy_UV.get(1),
-            ItemList.Hatch_Energy_UXV.get(1), ItemList.Hatch_Dynamo_LuV.get(1), ItemList.Hatch_Dynamo_ZPM.get(1),
-            ItemList.Hatch_Dynamo_UV.get(1), ItemList.Hatch_Dynamo_UXV.get(1), ItemList.Casing_Dim_Injector.get(1),
-            ItemList.Casing_Dim_Trans.get(1), ItemRefer.Advanced_Radiation_Protection_Plate.get(1) };
+            ItemList.Hatch_Energy_UHV.get(1), ItemList.Hatch_Dynamo_LuV.get(1), ItemList.Hatch_Dynamo_ZPM.get(1),
+            ItemList.Hatch_Dynamo_UV.get(1), ItemList.Hatch_Dynamo_UHV.get(1), ItemList.Casing_Dim_Injector.get(1),
+            ItemList.Casing_Dim_Trans.get(1), ItemRefer.Advanced_Radiation_Protection_Plate.get(1),
+            tectech.thing.CustomItemList.eM_energyTunnel8_UXV.get(1),
+            tectech.thing.CustomItemList.eM_dynamoTunnel8_UXV.get(1),
+            tectech.thing.CustomItemList.eM_energyTunnel9_UXV.get(1),
+            tectech.thing.CustomItemList.eM_dynamoTunnel9_UXV.get(1) };
 
         // start check assembly line recipes
         checkRecipe: for (var recipe : GTRecipe.RecipeAssemblyLine.sAssemblylineRecipes) {
@@ -465,7 +471,7 @@ public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
                     new Object[] { OrePrefixes.circuit.get(Materials.Infinite), 2L },
                     ItemList.UHV_Coil.get(2L),
                     ItemList.Electric_Pump_UHV.get(1L))
-                .itemOutputs(ItemList.Hatch_Energy_UXV.get(1))
+                .itemOutputs(ItemList.Hatch_Energy_UHV.get(1))
                 .fluidInputs(new FluidStack(ic2coolant, 16000), new FluidStack(solderIndalloy, 40 * 144))
                 .duration(50 * 20)
                 .eut(RECIPE_UHV)
@@ -525,10 +531,87 @@ public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
                     new Object[] { OrePrefixes.circuit.get(Materials.Infinite), 2L },
                     ItemList.UHV_Coil.get(2L),
                     ItemList.Electric_Pump_UHV.get(1L))
-                .itemOutputs(ItemList.Hatch_Dynamo_UXV.get(1))
+                .itemOutputs(ItemList.Hatch_Dynamo_UHV.get(1))
                 .fluidInputs(new FluidStack(ic2coolant, 16000), new FluidStack(solderIndalloy, 40 * 144))
                 .duration(50 * 20)
                 .eut(RECIPE_UHV)
+                .addTo(MASL);
+
+        }
+
+        // 4MA+ Lasers Target or Source
+        {
+
+            // 4M UXV Target
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTUtility.getIntegratedCircuit(1),
+                    ItemList.Hull_UXV.get(1),
+                    // copyAmount(128, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1)),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    setStackSize(ItemList.Sensor_UXV.get(1), 128),
+                    setStackSize(ItemList.Electric_Pump_UXV.get(1), 128),
+                    GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 32))
+                .itemOutputs(tectech.thing.CustomItemList.eM_energyTunnel8_UXV.get(1))
+                .fluidInputs(new FluidStack(solderUEV, 1_296 * 64 * 4))
+                .duration(106 * MINUTES + 40 * SECONDS)
+                .eut(RECIPE_UXV)
+                .addTo(MASL);
+
+            // 4M UXV Source
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTUtility.getIntegratedCircuit(1),
+                    ItemList.Hull_UXV.get(1),
+                    // copyAmount(128, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1)),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    setStackSize(ItemList.Emitter_UXV.get(1), 128),
+                    setStackSize(ItemList.Electric_Pump_UXV.get(1), 128),
+                    GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 32))
+                .itemOutputs(tectech.thing.CustomItemList.eM_dynamoTunnel8_UXV.get(1))
+                .fluidInputs(new FluidStack(solderUEV, 1_296 * 64 * 4))
+                .duration(106 * MINUTES + 40 * SECONDS)
+                .eut(RECIPE_UXV)
+                .addTo(MASL);
+
+            // 16M UXV Target
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTUtility.getIntegratedCircuit(2),
+                    ItemList.Hull_UXV.get(1),
+                    // copyAmount(256, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1)),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    setStackSize(ItemList.Sensor_UXV.get(1), 256),
+                    setStackSize(ItemList.Electric_Pump_UXV.get(1), 256),
+                    GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 64))
+                .itemOutputs(tectech.thing.CustomItemList.eM_energyTunnel9_UXV.get(1))
+                .fluidInputs(new FluidStack(solderUEV, 1_296 * 128 * 4))
+                .duration(213 * MINUTES + 20 * SECONDS)
+                .eut(RECIPE_UXV)
+                .addTo(MASL);
+
+            // 16M UXV Source
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTUtility.getIntegratedCircuit(2),
+                    ItemList.Hull_UXV.get(1),
+                    // copyAmount(256, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1)),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 64),
+                    setStackSize(ItemList.Emitter_UXV.get(1), 256),
+                    setStackSize(ItemList.Electric_Pump_UXV.get(1), 256),
+                    GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 64))
+                .itemOutputs(tectech.thing.CustomItemList.eM_dynamoTunnel9_UXV.get(1))
+                .fluidInputs(new FluidStack(solderUEV, 1_296 * 128 * 4))
+                .duration(213 * MINUTES + 20 * SECONDS)
+                .eut(RECIPE_UXV)
                 .addTo(MASL);
 
         }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/GTCMMachineRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/GTCMMachineRecipePool.java
@@ -222,6 +222,7 @@ import tectech.recipe.TTRecipeAdder;
 import tectech.thing.casing.TTCasingsContainer;
 import wanion.avaritiaddons.block.extremeautocrafter.BlockExtremeAutoCrafter;
 
+@SuppressWarnings("SpellCheckingInspection")
 public class GTCMMachineRecipePool implements IRecipePool {
 
     @Override
@@ -1694,7 +1695,7 @@ public class GTCMMachineRecipePool implements IRecipePool {
                 LASERpipe.get(64),
                 Laser_Lens_Special.get(1),
                 new Object[]{OrePrefixes.circuit.get(Materials.Bio), 1},
-                ItemList.Hatch_Energy_UXV.get(1)
+                ItemList.Hatch_Energy_UHV.get(1)
             )
             .fluidInputs(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(144))
             .itemOutputs(LaserSmartNode.get(1))

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/EcoSphereFakeRecipes/TreeGrowthSimulatorWithoutToolFakeRecipe.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/specialRecipe/EcoSphereFakeRecipes/TreeGrowthSimulatorWithoutToolFakeRecipe.java
@@ -184,19 +184,33 @@ public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
 
     void addFakeRecipe(ItemStack Sapling, ItemStack[] specialStacks, FluidStack inputFluid) {
         EnumMap<Mode, ItemStack> ProductMap = queryTreeProduct(Sapling);
-        ItemStack[] inputStacks = new ItemStack[Mode.values().length];
-        ItemStack[] outputStacks = new ItemStack[Mode.values().length];
+
+        // ItemStack[] inputStacks = new ItemStack[Mode.values().length];
+        // ItemStack[] outputStacks = new ItemStack[Mode.values().length];
+
+        ArrayList<ItemStack> input = new ArrayList<>();
+        ArrayList<ItemStack> output = new ArrayList<>();
+
         int count = 0;
         for (Mode mode : Mode.values()) {
             if (ProductMap != null && ProductMap.get(mode) != null) {
-                inputStacks[count] = IntegratedCircuitStack[count];
-                outputStacks[count] = ProductMap.get(mode)
+
+                input.add(IntegratedCircuitStack[count]);
+                ItemStack stack = ProductMap.get(mode)
                     .copy();
-                outputStacks[count].stackSize *= getModeMultiplier(mode);
+                stack.stackSize *= getModeMultiplier(mode);
+                output.add(stack);
+
+                // inputStacks[count] = IntegratedCircuitStack[count];
+                // outputStacks[count] = ProductMap.get(mode)
+                // .copy();
+                // outputStacks[count].stackSize *= getModeMultiplier(mode);
             }
             count++;
         }
-        addFakeRecipe(inputStacks, outputStacks, specialStacks, inputFluid);
+        var i = input.toArray(new ItemStack[0]);
+        var o = output.toArray(new ItemStack[0]);
+        addFakeRecipe(i, o, specialStacks, inputFluid);
     }
 
     void addFakeRecipe(ItemStack[] inputStacks, ItemStack[] outputStacks, ItemStack[] specialStacks,


### PR DESCRIPTION
修复了 eco导致的npe问题 #658 
修复了 由于 枚举名导致的部分配方错误和不可视生成了巨量配方的问题(MAX 原先对应UHV 写成了UXV)
修复了 新版本4M和16M激光仓不可视只能做4M舱室的问题 ( 我们那边270b2服务器测试和开发环境都发现了这个问)

配个图:
![2024-10-15_21 50 41](https://github.com/user-attachments/assets/19af864f-b808-4cb3-90d2-ac07bb3a75c5)
![2024-10-16_09 53 31](https://github.com/user-attachments/assets/e02c599c-8e79-473b-9c36-576e1996ec29)
