### PR TITLE
Add config opts for ManufacturingCenter and adjusted the Eu Reduction

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_ManufacturingCenter.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_ManufacturingCenter.java
@@ -17,9 +17,11 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.intellij.lang.annotations.MagicConstant;
 import org.jetbrains.annotations.NotNull;
 
 import com.Nxer.TwistSpaceTechnology.common.block.blockClass.Casings.multiuse.BlockMultiUseCore;
+import com.Nxer.TwistSpaceTechnology.config.Config;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.TextWithColor;
 import com.google.common.collect.BiMap;
@@ -56,15 +58,15 @@ import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 public class TST_ManufacturingCenter extends GTPPMultiBlockBase<TST_ManufacturingCenter>
     implements ISurvivalConstructable {
 
-    private static final int LOWEST_CORE_TIER = 5;
+    @MagicConstant(valuesFromClass = VoltageIndex.class)
+    private static final int LOWEST_CORE_TIER = VoltageIndex.IV;
 
-    private static final double SPEED_BONUS_BASE = 0.2F;
-    private static final double SPEED_BONUS_FOR_CORE_TIER = 0.5F;
+    private static final double SPEED_BONUS_BASE = Config.ManufacturingCenter_SpeedBonus_Base;
+    private static final double SPEED_BONUS_FOR_CORE_TIER = Config.ManufacturingCenter_SpeedBonus_Tier;
 
-    // for core tier at ZPM and UV
-    private static final double EU_REDUCTION_FOR_CORE_TIER = 0.2F;
+    private static final double EU_REDUCTION_FOR_CORE_TIER = Config.ManufacturingCenter_PowerReduction;
 
-    private static final int MAX_PARALLEL_MODIFIER = 2;
+    private static final int MAX_PARALLEL_MODIFIER = Config.ManufacturingCenter_MaxParallelModifier;
 
     public int coreTier = -1;
     public int casingCount = 0;
@@ -181,7 +183,7 @@ public class TST_ManufacturingCenter extends GTPPMultiBlockBase<TST_Manufacturin
     }
 
     private double getEuModifierAtCurrentCore() {
-        return 1.0 - (EU_REDUCTION_FOR_CORE_TIER * Math.max(0, coreTier - LOWEST_CORE_TIER - 2));
+        return 1.0 - (EU_REDUCTION_FOR_CORE_TIER * Math.max(0, coreTier - LOWEST_CORE_TIER));
     }
 
     // endregion
@@ -265,7 +267,7 @@ public class TST_ManufacturingCenter extends GTPPMultiBlockBase<TST_Manufacturin
             .addInfo(
                 TextEnums.tr(
                     "ManufacturingCenter_Tooltips_5",
-                    TextWithColor.getTierName(VoltageIndex.IV),
+                    TextWithColor.getTierName(LOWEST_CORE_TIER),
                     TextWithColor.percentage(SPEED_BONUS_FOR_CORE_TIER * 100)))
             // #tr ManufacturingCenter_Tooltips_6
             // # Each Core Tier over %s gains §b%s§7 EU/t Reduction.
@@ -273,7 +275,7 @@ public class TST_ManufacturingCenter extends GTPPMultiBlockBase<TST_Manufacturin
             .addInfo(
                 TextEnums.tr(
                     "ManufacturingCenter_Tooltips_6",
-                    TextWithColor.getTierName(VoltageIndex.LuV),
+                    TextWithColor.getTierName(LOWEST_CORE_TIER),
                     TextWithColor.percentage(EU_REDUCTION_FOR_CORE_TIER * 100)))
             // #tr ManufacturingCenter_Tooltips_7
             // # Max parallel is §b%s§7 max voltage tier.

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
@@ -324,7 +324,7 @@ public class Config {
     public static boolean Enable_BallLightning = true;
     public static int WirelessModeExtraEuCost_BallLightning = 64;
     public static int WirelessModeTickEveryProcess_BallLightning = 64;
-    // end region
+    // endregion
 
     // region StarcoreMiner
     public static boolean Enable_StarcoreMiner = true;
@@ -451,6 +451,13 @@ public class Config {
 
     // region Industrial Alchemy Tower
     public static boolean Enable_IndustrialAlchemyTower = true;
+    // endregion
+
+    // region ManufacturingCenter
+    public static float ManufacturingCenter_SpeedBonus_Base = 0.2F;
+    public static float ManufacturingCenter_SpeedBonus_Tier = 0.5F;
+    public static float ManufacturingCenter_PowerReduction = 0.2F;
+    public static int ManufacturingCenter_MaxParallelModifier = 2;
     // endregion
 
     public static void synchronizeConfiguration(File configFile) {
@@ -793,6 +800,13 @@ public class Config {
 
         // region Industrial Alchemy Tower
         Enable_IndustrialAlchemyTower = configuration.getBoolean("Enable Industrial Alchemy Tower",IndustrialAlchemyTower,Enable_IndustrialAlchemyTower,"Enable Industrial Alchemy Tower");
+        // endregion
+
+        // region ManufacturingCenter
+        ManufacturingCenter_SpeedBonus_Base = configuration.getFloat("Speed Bonus Base", "ManufacturingCenter", ManufacturingCenter_SpeedBonus_Base, 0.0F, Float.MAX_VALUE, "The Base Speed Bonus");
+        ManufacturingCenter_SpeedBonus_Tier = configuration.getFloat("Speed Bonus Tier", "ManufacturingCenter", ManufacturingCenter_SpeedBonus_Tier, 0.0F, Float.MAX_VALUE, "The Speed Bonus for each tier over the lowest tier (not included)");
+        ManufacturingCenter_PowerReduction = configuration.getFloat("Power Reduction", "ManufacturingCenter", ManufacturingCenter_PowerReduction, 0.0F, Float.MAX_VALUE, "The Power Reduction for each tier over the lowest tier (not included)");
+        ManufacturingCenter_MaxParallelModifier = configuration.getInt("Max Parallel Modifier", "ManufacturingCenter", ManufacturingCenter_MaxParallelModifier, 1, Integer.MAX_VALUE, "The maximum parallel modifier");
         // endregion
 
         TST_CleanRoom.loadConfig(configuration);

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
@@ -456,7 +456,7 @@ public class Config {
     // region ManufacturingCenter
     public static float ManufacturingCenter_SpeedBonus_Base = 0.2F;
     public static float ManufacturingCenter_SpeedBonus_Tier = 0.5F;
-    public static float ManufacturingCenter_PowerReduction = 0.2F;
+    public static float ManufacturingCenter_PowerReduction = 0.15F;
     public static int ManufacturingCenter_MaxParallelModifier = 2;
     // endregion
 


### PR DESCRIPTION
Add configuration options for Manufacturing Centers.
EU Reduction for only ZPM and UV by 20% and 40% are changed to 15% on each tier over IV (Max 45% at UV).