### PR TITLE
Blood Hatch Glitch Fixes

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_BloodOrbHatch.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_BloodOrbHatch.java
@@ -53,7 +53,8 @@ public class TST_BloodOrbHatch extends MTEHatchFluidGenerator {
         // #tr Tooltip_BloodOrbHatch_5
         // # Deactivating the Hatch will refund the Life Essence back to the Blood Orb.
         // #zh_CN 关闭血液仓将会把生命本质输回气血宝珠
-        TextEnums.tr("Tooltip_BloodOrbHatch_5"), TextEnums.Author_Taskeren.getText(), };
+        TextEnums.tr("Tooltip_BloodOrbHatch_5"), TextEnums.Author_Taskeren.getText(),
+        TextEnums.Mod_TwistSpaceTechnology.getText() };
 
     private static final String[] TOOLTIP = new String[] { TextEnums.tr("Tooltip_BloodOrbHatch_3"),
         TextEnums.tr("Tooltip_BloodOrbHatch_4"), TextEnums.tr("Tooltip_BloodOrbHatch_5"), };

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_BloodOrbHatch.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_BloodOrbHatch.java
@@ -8,6 +8,7 @@ import net.minecraftforge.fluids.Fluid;
 import org.jetbrains.annotations.Nullable;
 
 import com.Nxer.TwistSpaceTechnology.util.BloodMagicHelper;
+import com.Nxer.TwistSpaceTechnology.util.MathUtils;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
@@ -169,7 +170,7 @@ public class TST_BloodOrbHatch extends MTEHatchFluidGenerator {
             return false;
         }
 
-        int maxDrainAmount = Math.min(getCapacity() - getFluidAmount(), getMaxCanDrainFromOrb());
+        int maxDrainAmount = MathUtils.clamp(getCapacity() - getFluidAmount(), 0, getMaxCanDrainFromOrb());
         int drainedAmount = drainFromOrb(maxDrainAmount);
         if (drainedAmount > 0) {
             super.fill(FluidUtils.getFluidStack(getFluidToGenerate(), drainedAmount), true);
@@ -187,9 +188,12 @@ public class TST_BloodOrbHatch extends MTEHatchFluidGenerator {
             getBaseMetaTileEntity().setActive(true);
             this.mMaxProgresstime = getMaxTickTime();
             if (++this.mProgresstime >= this.mMaxProgresstime) {
-                if (this.canTankBeFilled()) {
+                if (this.getOrbItemStack() == null) {
+                    this.mFluid = null;
+                } else if (this.canTankBeFilled()) {
                     this.addFluidToHatch(aTick);
                 }
+                this.mProgresstime = 0;
             }
         } else {
             getBaseMetaTileEntity().setActive(false);

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/util/BloodMagicHelper.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/util/BloodMagicHelper.java
@@ -103,4 +103,32 @@ public class BloodMagicHelper {
     public static FluidStack getLifeEssence(int amount) {
         return FluidUtils.getFluidStack("lifeessence", amount);
     }
+
+    /**
+     * Adds blood to the owner's network.
+     *
+     * @param ownerName the network owner name
+     * @param lpAmount  the amount of blood
+     * @return the amount of blood added to the network
+     */
+    public static int addBloodToNetwork(String ownerName, int lpAmount) {
+        var maxOrb = SoulNetworkHandler.getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(ownerName));
+        return SoulNetworkHandler.addCurrentEssenceToMaximum(ownerName, lpAmount, maxOrb);
+    }
+
+    /**
+     * Adds blood to the network of blood orb's owner.
+     *
+     * @param orbStack the blood orb
+     * @param lpAmount the amount of blood
+     * @return the amount of blood added to the network
+     */
+    public static int addBloodToNetwork(ItemStack orbStack, int lpAmount) {
+        var ownerName = getOrbOwnerName(orbStack);
+        if (ownerName != null) {
+            return addBloodToNetwork(ownerName, lpAmount);
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/main/resources/assets/gtnhcommunitymod/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhcommunitymod/lang/en_US.lang
@@ -1609,3 +1609,4 @@ tc.research_name.TST_ARCANE_HOLE=Arcane Hole
 tc.research_text.TST_ARCANE_HOLE=Block in the void
 tc.research_text.TST_ARCANE_HOLE.1=Can be used to replace the warded glass on both sides of industrial alchemy tower. Perhaps it's still a good building block?
 Tooltip_Channel_Helper=You can use the §9 channel:§echisel§7 to automatically convert chisel blocks when building, and you can see nei to preview the available blocks
+Tooltip_BloodOrbHatch_5=Deactivating the Hatch will refund the Life Essence back to the Blood Orb.

--- a/src/main/resources/assets/gtnhcommunitymod/lang/zh_CN.lang
+++ b/src/main/resources/assets/gtnhcommunitymod/lang/zh_CN.lang
@@ -1609,3 +1609,4 @@ tc.research_name.TST_ARCANE_HOLE=奥术裂隙
 tc.research_text.TST_ARCANE_HOLE=虚空中之物
 tc.research_text.TST_ARCANE_HOLE.1=可以用来替代工业炼金塔两侧的守卫者玻璃。或许还是一种不错的建筑方块？
 Tooltip_Channel_Helper=可以使用§9信道:§echisel§7进行搭建时自动转换凿子方块，可以查看nei进行预览可用方块
+Tooltip_BloodOrbHatch_5=关闭血液仓将会把生命本质输回气血宝珠


### PR DESCRIPTION
- [X] Bloods will be voided after the Orb is taken from the Hatch.
- [x] Return all the bloods in the hatch when the hatch is turned off.
      This is used to recycle the drained bloods when the hatch is no longer needed. But who cares about these little amount of bloods. :\
- [x] Fix the Infinity blood generation bug.