### PR TITLE
chore: Remove some usages of deprecated render clasases

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_Hatch_RackComputationMonitor.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_Hatch_RackComputationMonitor.java
@@ -41,7 +41,7 @@ import gregtech.api.interfaces.modularui.IAddUIWidgets;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
-import gregtech.api.objects.GTRenderedTexture;
+import gregtech.api.render.TextureFactory;
 import tectech.TecTech;
 import tectech.thing.gui.TecTechUITextures;
 import tectech.util.TTUtility;
@@ -113,12 +113,12 @@ public class GT_Hatch_RackComputationMonitor extends MTEHatch implements IAddGre
 
     @Override
     public ITexture[] getTexturesActive(ITexture aBaseTexture) {
-        return new ITexture[] { aBaseTexture, new GTRenderedTexture(EM_R_ACTIVE) };
+        return new ITexture[] { aBaseTexture, TextureFactory.of(EM_R_ACTIVE) };
     }
 
     @Override
     public ITexture[] getTexturesInactive(ITexture aBaseTexture) {
-        return new ITexture[] { aBaseTexture, new GTRenderedTexture(EM_R) };
+        return new ITexture[] { aBaseTexture, TextureFactory.of(EM_R) };
     }
 
     @Override

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_MetaTileEntity_Hatch_Air.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_MetaTileEntity_Hatch_Air.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fluids.Fluid;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.objects.GTRenderedTexture;
+import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.util.minecraft.FluidUtils;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchFluidGenerator;
@@ -87,11 +87,11 @@ public class GT_MetaTileEntity_Hatch_Air extends MTEHatchFluidGenerator {
 
     @Override
     public ITexture[] getTexturesActive(final ITexture aBaseTexture) {
-        return new ITexture[] { aBaseTexture, new GTRenderedTexture(TexturesGtBlock.Overlay_Hatch_Muffler_Adv) };
+        return new ITexture[] { aBaseTexture, TextureFactory.of(TexturesGtBlock.Overlay_Hatch_Muffler_Adv) };
     }
 
     @Override
     public ITexture[] getTexturesInactive(final ITexture aBaseTexture) {
-        return new ITexture[] { aBaseTexture, new GTRenderedTexture(TexturesGtBlock.Overlay_Hatch_Muffler_Adv) };
+        return new ITexture[] { aBaseTexture, TextureFactory.of(TexturesGtBlock.Overlay_Hatch_Muffler_Adv) };
     }
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_MetaTileEntity_Pipe_EnergySmart.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_MetaTileEntity_Pipe_EnergySmart.java
@@ -25,7 +25,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTETieredMachineBlock;
-import gregtech.api.objects.GTRenderedTexture;
+import gregtech.api.render.TextureFactory;
 import tectech.mechanics.pipe.IConnectsToEnergyTunnel;
 import tectech.thing.metaTileEntity.hatch.MTEHatchDynamoTunnel;
 import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyTunnel;
@@ -90,11 +90,11 @@ public class GT_MetaTileEntity_Pipe_EnergySmart extends MTETieredMachineBlock im
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection aFacing,
         int colorIndex, boolean aActive, boolean redstoneLevel) {
         if (side == aFacing) {
-            return new ITexture[] { new GTRenderedTexture(EMpipe), OVERLAYS_ENERGY_IN_LASER_TT[mTier],
-                new GTRenderedTexture(EMCandyActive, Dyes.getModulation(colorIndex, MACHINE_METAL.getRGBA())) };
+            return new ITexture[] { TextureFactory.of(EMpipe), OVERLAYS_ENERGY_IN_LASER_TT[mTier],
+                TextureFactory.of(EMCandyActive, Dyes.getModulation(colorIndex, MACHINE_METAL.getRGBA())) };
         } else {
-            return new ITexture[] { new GTRenderedTexture(EMpipe),
-                new GTRenderedTexture(EMCandyActive, Dyes.getModulation(colorIndex, MACHINE_METAL.getRGBA())) };
+            return new ITexture[] { TextureFactory.of(EMpipe),
+                TextureFactory.of(EMCandyActive, Dyes.getModulation(colorIndex, MACHINE_METAL.getRGBA())) };
         }
     }
 


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT5-Unofficial/pull/3773

I couldn't update the steam multis, as their texture methods have a signature that can't be worked around currently. But only these two classes will have to be updated later.

This does not rely on a newer GT version, TextureFactory will work fine on both 2.7 and 2.8, but GTRenderedTexture will no longer exist in 2.8