### PR TITLE
add non-cyclized recipes of Perfect Lapotron Crystal and Perfect Energy Crystal and configurated

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
@@ -234,6 +234,7 @@ public class Config {
     public static int SpeedMultiplier_CrystallineInfinitierMode_CrystallineInfinitier = 1;
     public static int ParallelMultiplier_CrystallineInfinitier = 1;
     public static byte FieldTier_EnablePerfectOverclock_CrystallineInfinitier = 3;
+    public static boolean PerfectCrystalRecipeNonCyclized = false;
     // endregion
 
     // region Scavenger
@@ -672,6 +673,7 @@ public class Config {
         SpeedMultiplier_CrystallineInfinitierMode_CrystallineInfinitier = configuration.getInt("SpeedMultiplier_CrystallineInfinitierMode_CrystallineInfinitier", CrystallineInfinitier, SpeedMultiplier_CrystallineInfinitierMode_CrystallineInfinitier, 1, 64, "Speed Multiplier of Crystalline Infinitier in Crystalline Infinitier mode. Type: int");
         ParallelMultiplier_CrystallineInfinitier = configuration.getInt("ParallelMultiplier_CrystallineInfinitier", CrystallineInfinitier, ParallelMultiplier_CrystallineInfinitier, 1, 256, "Parallel Multiplier of Crystalline Infinitier. The final parallel will be multiplied this value. Type: int");
         FieldTier_EnablePerfectOverclock_CrystallineInfinitier = (byte) configuration.getInt("FieldTier_EnablePerfectOverclock_CrystallineInfinitier", CrystallineInfinitier, FieldTier_EnablePerfectOverclock_CrystallineInfinitier, 1, 11, "When field generator block tier is beyond this value, machine will enable perfect overclock. 3 is the lowest EOH block. Type: byte");
+        PerfectCrystalRecipeNonCyclized = configuration.getBoolean("PerfectCrystalRecipeNonCyclized", CrystallineInfinitier, PerfectCrystalRecipeNonCyclized, "Generate direct recipe of Perfect Lapotron Crystal and Perfect Energy Crystal.");
         // endregion
 
         // region Molecule Deconstructor

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CrystallineInfinitierRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CrystallineInfinitierRecipePool.java
@@ -17,6 +17,7 @@ import net.minecraftforge.oredict.OreDictionary;
 import com.Nxer.TwistSpaceTechnology.common.init.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
+import com.Nxer.TwistSpaceTechnology.config.Config;
 import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.dreammaster.gthandler.CustomItemList;
 
@@ -33,7 +34,6 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-// spotless:off
 public class CrystallineInfinitierRecipePool implements IRecipePool {
 
     @Override
@@ -45,8 +45,7 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
         final IRecipeMap CI = GTCMRecipe.CrystallineInfinitierRecipes;
 
         // region Adv Nether Stars
-        GTValues.RA
-            .stdBuilder()
+        GTValues.RA.stdBuilder()
             .itemInputs(new ItemStack(Items.nether_star))
             .fluidInputs(Materials.Neutronium.getMolten(144 * 2))
             .itemOutputs(ItemList.Gravistar.get(1))
@@ -54,8 +53,7 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
             .duration(20 * 16)
             .addTo(CI);
 
-        GTValues.RA
-            .stdBuilder()
+        GTValues.RA.stdBuilder()
             .itemInputs(new ItemStack(Items.nether_star))
             .fluidInputs(Materials.Infinity.getMolten(144 * 2))
             .itemOutputs(ItemList.NuclearStar.get(1))
@@ -66,10 +64,9 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
         // endregion
 
         // region Cubic Zirconia
-        GTValues.RA
-            .stdBuilder()
-            .itemInputs(WerkstoffMaterialPool.Zirconium.get(OrePrefixes.dust,10))
-            .fluidInputs(Materials.Oxygen.getGas(1000*20))
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.Zirconium.get(OrePrefixes.dust, 10))
+            .fluidInputs(Materials.Oxygen.getGas(1000 * 20))
             .itemOutputs(WerkstoffLoader.CubicZirconia.get(OrePrefixes.gem, 30))
             .eut(RECIPE_HV)
             .duration(20 * 144)
@@ -85,15 +82,6 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
             .duration(20 * 5)
             .addTo(HM);
 
-        // Growth
-        GTValues.RA.stdBuilder()
-            .itemInputs(GTCMItemList.LapotronShard.get(1), MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 8))
-            .fluidInputs(Materials.VibrantAlloy.getMolten(144 * 2))
-            .itemOutputs(GTCMItemList.PerfectLapotronCrystal.get(1))
-            .eut(RECIPE_UHV)
-            .duration(20 * 30)
-            .addTo(CI);
-
         // The first piece
         GTValues.RA.stdBuilder()
             .itemInputs(
@@ -103,11 +91,42 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
                 CustomItemList.LapotronDust.get(64))
             .fluidInputs(MaterialPool.HolmiumGarnet.getMolten(144 * 256))
             .itemOutputs(GTCMItemList.LapotronShard.get(1))
-
             .outputChances(999)
             .eut(RECIPE_UHV)
             .duration(20 * 3000)
             .addTo(CI);
+
+        // Growth
+        if (Config.PerfectCrystalRecipeNonCyclized) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(GTCMItemList.LapotronShard.get(1), MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 8))
+                .fluidInputs(Materials.VibrantAlloy.getMolten(144 * 2))
+                .itemOutputs(GTCMItemList.PerfectLapotronCrystal.get(16))
+                .eut(RECIPE_UHV)
+                .duration(20 * 30)
+                .addTo(CI);
+
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTCMItemList.PerfectLapotronCrystal.get(0),
+                    MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 64),
+                    MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 64),
+                    MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 64),
+                    MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 64))
+                .fluidInputs(Materials.VibrantAlloy.getMolten(144 * 64))
+                .itemOutputs(GTCMItemList.PerfectLapotronCrystal.get(1))
+                .eut(RECIPE_UHV)
+                .duration(20 * 300)
+                .addTo(CI);
+        } else {
+            GTValues.RA.stdBuilder()
+                .itemInputs(GTCMItemList.LapotronShard.get(1), MaterialPool.HolmiumGarnet.get(OrePrefixes.dust, 8))
+                .fluidInputs(Materials.VibrantAlloy.getMolten(144 * 2))
+                .itemOutputs(GTCMItemList.PerfectLapotronCrystal.get(4))
+                .eut(RECIPE_UHV)
+                .duration(20 * 30)
+                .addTo(CI);
+        }
 
         // Holmium Garnet Dust
         // gt mixer
@@ -253,41 +272,68 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
         // Shard
         GTValues.RA.stdBuilder()
             .itemInputs(GTCMItemList.PerfectEnergyCrystal.get(1))
-
             .itemOutputs(GTCMItemList.EnergyCrystalShard.get(64))
-
             .eut(RECIPE_ZPM)
             .duration(20 * 5)
             .addTo(HM);
-
-        // Growth
-        GTValues.RA.stdBuilder()
-            .itemInputs(GTCMItemList.EnergyCrystalShard.get(1), ItemList.IC2_Energium_Dust.get(64))
-            .fluidInputs(Materials.EnergeticAlloy.getMolten(144 * 2))
-            .itemOutputs(GTCMItemList.PerfectEnergyCrystal.get(1))
-
-            .eut(RECIPE_ZPM)
-            .duration(20 * 30)
-            .addTo(CI);
 
         // The first piece
         GTValues.RA.stdBuilder()
             .itemInputs(ItemList.IC2_Energium_Dust.get(64), ItemList.IC2_Energium_Dust.get(64))
             .fluidInputs(Materials.Redstone.getMolten(144 * 1024))
             .itemOutputs(GTCMItemList.EnergyCrystalShard.get(1))
-
             .outputChances(1111)
             .eut(RECIPE_ZPM)
             .duration(20 * 3000)
             .addTo(AC);
 
+        // Growth
+        if (Config.PerfectCrystalRecipeNonCyclized) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(GTCMItemList.EnergyCrystalShard.get(1), ItemList.IC2_Energium_Dust.get(64))
+                .fluidInputs(Materials.EnergeticAlloy.getMolten(144 * 2))
+                .itemOutputs(GTCMItemList.PerfectEnergyCrystal.get(16))
+                .eut(RECIPE_ZPM)
+                .duration(20 * 30)
+                .addTo(CI);
+
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTCMItemList.PerfectEnergyCrystal.get(0),
+                    ItemList.IC2_Energium_Dust.get(64),
+                    ItemList.IC2_Energium_Dust.get(64),
+                    ItemList.IC2_Energium_Dust.get(64),
+                    ItemList.IC2_Energium_Dust.get(64))
+                .fluidInputs(Materials.EnergeticAlloy.getMolten(144 * 64))
+                .itemOutputs(GTCMItemList.PerfectEnergyCrystal.get(1))
+                .eut(RECIPE_ZPM)
+                .duration(20 * 300)
+                .addTo(CI);
+        } else {
+            GTValues.RA.stdBuilder()
+                .itemInputs(GTCMItemList.EnergyCrystalShard.get(1), ItemList.IC2_Energium_Dust.get(64))
+                .fluidInputs(Materials.EnergeticAlloy.getMolten(144 * 2))
+                .itemOutputs(GTCMItemList.PerfectEnergyCrystal.get(4))
+                .eut(RECIPE_ZPM)
+                .duration(20 * 30)
+                .addTo(CI);
+        }
+
+        // Autoclave
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTCMItemList.EnergyCrystalShard.get(1), ItemList.IC2_Energium_Dust.get(64))
+            .fluidInputs(Materials.EnergeticAlloy.getMolten(144 * 16))
+            .itemOutputs(GTCMItemList.PerfectEnergyCrystal.get(1))
+            .outputChances(9900)
+            .eut(RECIPE_ZPM)
+            .duration(20 * 300)
+            .addTo(RecipeMaps.autoclaveRecipes);
+
         // Chip
         for (ItemStack itemStack : OreDictionary.getOres("craftingLensRed")) {
             GTValues.RA.stdBuilder()
                 .itemInputs(GTUtility.copyAmountUnsafe(0, itemStack), GTCMItemList.PerfectEnergyCrystal.get(1))
-
                 .itemOutputs(CustomItemList.EngravedEnergyChip.get(64), CustomItemList.EngravedEnergyChip.get(64))
-
                 .noOptimize()
                 .eut(RECIPE_UV)
                 .duration(20 * 15)
@@ -303,7 +349,6 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
             .itemOutputs(
                 WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemExquisite, 64),
                 WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemExquisite, 64))
-
             .eut(RECIPE_UHV)
             .duration(20 * 10)
             .addTo(CI);
@@ -314,25 +359,19 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
 
         // Monocrystalline Silicon Boule
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTUtility.getIntegratedCircuit(2),
-                Materials.GalliumArsenide.getDust(1))
-            .fluidInputs(Materials.SiliconSG.getMolten(144*64))
+            .itemInputs(GTUtility.getIntegratedCircuit(2), Materials.GalliumArsenide.getDust(1))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 64))
             .itemOutputs(ItemList.Circuit_Silicon_Ingot.get(4))
-
             .eut(RECIPE_MV)
-            .duration(20*450)
+            .duration(20 * 450)
             .addTo(CI);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTUtility.getIntegratedCircuit(2),
-                Materials.GalliumArsenide.getDust(1))
-            .fluidInputs(Materials.Silicon.getMolten(144*64))
+            .itemInputs(GTUtility.getIntegratedCircuit(2), Materials.GalliumArsenide.getDust(1))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 64))
             .itemOutputs(ItemList.Circuit_Silicon_Ingot.get(2))
-
             .eut(RECIPE_MV)
-            .duration(20*450)
+            .duration(20 * 450)
             .addTo(CI);
 
         // Phosphorus doped Monocrystalline Silicon Boule
@@ -341,11 +380,10 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
                 GTUtility.getIntegratedCircuit(1),
                 Materials.GalliumArsenide.getDust(2),
                 Materials.Phosphorus.getDust(16))
-            .fluidInputs(Materials.SiliconSG.getMolten(144*128))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 128))
             .itemOutputs(ItemList.Circuit_Silicon_Ingot2.get(4))
-
             .eut(RECIPE_HV)
-            .duration(20*150)
+            .duration(20 * 150)
             .addTo(CI);
 
         GTValues.RA.stdBuilder()
@@ -353,183 +391,163 @@ public class CrystallineInfinitierRecipePool implements IRecipePool {
                 GTUtility.getIntegratedCircuit(1),
                 Materials.GalliumArsenide.getDust(2),
                 Materials.Phosphorus.getDust(16))
-            .fluidInputs(Materials.Silicon.getMolten(144*128))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 128))
             .itemOutputs(ItemList.Circuit_Silicon_Ingot2.get(2))
-
             .eut(RECIPE_HV)
-            .duration(20*150)
+            .duration(20 * 150)
             .addTo(CI);
 
         // Naquadah doped Monocrystalline Silicon Boule
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(4),
-                        Materials.Naquadah.getDust(2))
-                    .fluidInputs(Materials.SiliconSG.getMolten(144*256))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(4))
-
-                    .eut(RECIPE_EV)
-                    .duration(20*256)
-                    .addTo(CI);
-
-        GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(4),
-                        Materials.Naquadah.getDust(2))
-                    .fluidInputs(Materials.Silicon.getMolten(144*256))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(2))
-
-                    .eut(RECIPE_EV)
-                    .duration(20*256)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(4),
+                Materials.Naquadah.getDust(2))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 256))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(4))
+            .eut(RECIPE_EV)
+            .duration(20 * 256)
+            .addTo(CI);
 
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(4),
-                        GGMaterial.naquadahine.get(OrePrefixes.dust, 6))
-                    .fluidInputs(Materials.SiliconSG.getMolten(144*256))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(4))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*16)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(4),
+                Materials.Naquadah.getDust(2))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 256))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(2))
+            .eut(RECIPE_EV)
+            .duration(20 * 256)
+            .addTo(CI);
 
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(4),
-                        GGMaterial.naquadahine.get(OrePrefixes.dust, 6))
-                    .fluidInputs(Materials.Silicon.getMolten(144*256))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(2))
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(4),
+                GGMaterial.naquadahine.get(OrePrefixes.dust, 6))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 256))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(4))
+            .eut(RECIPE_IV)
+            .duration(20 * 16)
+            .addTo(CI);
 
-                    .eut(RECIPE_IV)
-                    .duration(20*16)
-                    .addTo(CI);
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(4),
+                GGMaterial.naquadahine.get(OrePrefixes.dust, 6))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 256))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(2))
+            .eut(RECIPE_IV)
+            .duration(20 * 16)
+            .addTo(CI);
 
         // Europium doped Monocrystalline Silicon Boule
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(8),
-                        Materials.Europium.getDust(4))
-                    .fluidInputs(Materials.SiliconSG.getMolten(144*512))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot4.get(4))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*336)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(8),
+                Materials.Europium.getDust(4))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 512))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot4.get(4))
+            .eut(RECIPE_IV)
+            .duration(20 * 336)
+            .addTo(CI);
 
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(8),
-                        Materials.Europium.getDust(4))
-                    .fluidInputs(Materials.Silicon.getMolten(144*512))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot4.get(2))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*336)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(8),
+                Materials.Europium.getDust(4))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 512))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot4.get(2))
+            .eut(RECIPE_IV)
+            .duration(20 * 336)
+            .addTo(CI);
 
         // Americium doped Monocrystalline Silicon Boule
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(16),
-                        Materials.Americium.getDust(4))
-                    .fluidInputs(Materials.SiliconSG.getMolten(144*1024))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot5.get(4))
-
-                    .eut(RECIPE_LuV)
-                    .duration(20*450)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(16),
+                Materials.Americium.getDust(4))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 1024))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot5.get(4))
+            .eut(RECIPE_LuV)
+            .duration(20 * 450)
+            .addTo(CI);
 
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(1),
-                        Materials.GalliumArsenide.getDust(16),
-                        Materials.Americium.getDust(4))
-                    .fluidInputs(Materials.Silicon.getMolten(144*1024))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot5.get(2))
-
-                    .eut(RECIPE_LuV)
-                    .duration(20*450)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
+                Materials.GalliumArsenide.getDust(16),
+                Materials.Americium.getDust(4))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 1024))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot5.get(2))
+            .eut(RECIPE_LuV)
+            .duration(20 * 450)
+            .addTo(CI);
 
         // Optical Enriched Crystalline Silicon Boule
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(3),
-                        ItemList.Field_Generator_UIV.get(0),
-                        Materials.GalliumArsenide.getDust(16),
-                        Materials.Americium.getDust(4))
-                    .fluidInputs(
-                        Materials.SiliconSG.getMolten(144*1024),
-                        Materials.UUMatter.getFluid(1000*32))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot6.get(4))
-
-                    .eut(RECIPE_UEV)
-                    .duration(20*30)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(3),
+                ItemList.Field_Generator_UIV.get(0),
+                Materials.GalliumArsenide.getDust(16),
+                Materials.Americium.getDust(4))
+            .fluidInputs(Materials.SiliconSG.getMolten(144 * 1024), Materials.UUMatter.getFluid(1000 * 32))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot6.get(4))
+            .eut(RECIPE_UEV)
+            .duration(20 * 30)
+            .addTo(CI);
 
         GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        GTUtility.getIntegratedCircuit(3),
-                        ItemList.Field_Generator_UIV.get(0),
-                        Materials.GalliumArsenide.getDust(16),
-                        Materials.Americium.getDust(4))
-                    .fluidInputs(
-                        Materials.Silicon.getMolten(144*1024),
-                        Materials.UUMatter.getFluid(1000*32))
-                    .itemOutputs(ItemList.Circuit_Silicon_Ingot6.get(2))
-
-                    .eut(RECIPE_UEV)
-                    .duration(20*30)
-                    .addTo(CI);
+            .itemInputs(
+                GTUtility.getIntegratedCircuit(3),
+                ItemList.Field_Generator_UIV.get(0),
+                Materials.GalliumArsenide.getDust(16),
+                Materials.Americium.getDust(4))
+            .fluidInputs(Materials.Silicon.getMolten(144 * 1024), Materials.UUMatter.getFluid(1000 * 32))
+            .itemOutputs(ItemList.Circuit_Silicon_Ingot6.get(2))
+            .eut(RECIPE_UEV)
+            .duration(20 * 30)
+            .addTo(CI);
 
         // endregion
 
         // region AE Quartz
         // Nether Quartz
         GTValues.RA.stdBuilder()
-                    .itemInputs(Materials.NetherQuartz.getDust(64))
-                    .fluidInputs(Materials.Water.getFluid(1000))
-                    .itemOutputs(
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,11),
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,11))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*8)
-                    .addTo(CI);
+            .itemInputs(Materials.NetherQuartz.getDust(64))
+            .fluidInputs(Materials.Water.getFluid(1000))
+            .itemOutputs(
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 11),
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 11))
+            .eut(RECIPE_IV)
+            .duration(20 * 8)
+            .addTo(CI);
 
         // Certus Quartz
         GTValues.RA.stdBuilder()
-                    .itemInputs(Materials.CertusQuartz.getDust(64))
-                    .fluidInputs(Materials.Water.getFluid(1000))
-                    .itemOutputs(
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,10),
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,10))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*8)
-                    .addTo(CI);
+            .itemInputs(Materials.CertusQuartz.getDust(64))
+            .fluidInputs(Materials.Water.getFluid(1000))
+            .itemOutputs(
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 10),
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 10))
+            .eut(RECIPE_IV)
+            .duration(20 * 8)
+            .addTo(CI);
 
         // Fluix Quartz
         GTValues.RA.stdBuilder()
-                    .itemInputs(Materials.Fluix.getDust(64))
-                    .fluidInputs(Materials.Water.getFluid(1000))
-                    .itemOutputs(
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,12),
-                        GTModHandler.getModItem("appliedenergistics2","item.ItemMultiMaterial",64,12))
-
-                    .eut(RECIPE_IV)
-                    .duration(20*8)
-                    .addTo(CI);
-
+            .itemInputs(Materials.Fluix.getDust(64))
+            .fluidInputs(Materials.Water.getFluid(1000))
+            .itemOutputs(
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 12),
+                GTModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 64, 12))
+            .eut(RECIPE_IV)
+            .duration(20 * 8)
+            .addTo(CI);
 
     }
 }
-// spotless:on


### PR DESCRIPTION
 - Increase Perfect Lapotron Crystal and Perfect Energy Crystal output amount 1 -> 4
 - Add non-cyclized recipes of Perfect Lapotron Crystal and Perfect Energy Crystal
 - Set config to control non-cyclized recipes generating, default is false
 - Spotless