### PR TITLE
Adjust circuit recipes

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
@@ -1,6 +1,7 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.expanded;
 
 import static com.Nxer.TwistSpaceTechnology.util.TstUtils.copyAmountFluid;
+import static com.Nxer.TwistSpaceTechnology.util.TstUtils.mergeSameFluid;
 import static com.Nxer.TwistSpaceTechnology.util.TstUtils.removeIntegratedCircuitFromStacks;
 import static com.Nxer.TwistSpaceTechnology.util.TstUtils.setStackSize;
 import static com.gtnewhorizons.gtnhintergalactic.recipe.IGRecipeMaps.spaceAssemblerRecipes;
@@ -462,22 +463,6 @@ public class MiracleTopRecipePool implements IRecipePool {
             oRecipe.mDuration,
             oRecipe.mEUt,
             0);
-    }
-
-    public FluidStack[] mergeSameFluid(FluidStack[] fluidStacks) {
-
-        Map<Fluid, Integer> fluidMap = new LinkedHashMap<>();
-
-        for (FluidStack aStack : fluidStacks) {
-            fluidMap.put(aStack.getFluid(), fluidMap.getOrDefault(aStack.getFluid(), 0) + aStack.amount);
-        }
-
-        ArrayList<FluidStack> mergedList = new ArrayList<>();
-        for (Map.Entry<Fluid, Integer> entry : fluidMap.entrySet()) {
-            mergedList.add(new FluidStack(entry.getKey(), entry.getValue()));
-        }
-
-        return mergedList.toArray(new FluidStack[0]);
     }
 
     private boolean isRecipeInputItemSame(GTRecipe a, GTRecipe b) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
@@ -21,14 +21,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/PreciseHighEnergyPhotonicQuantumMasterRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/PreciseHighEnergyPhotonicQuantumMasterRecipePool.java
@@ -116,7 +116,7 @@ public class PreciseHighEnergyPhotonicQuantumMasterRecipePool implements IRecipe
                 ItemList.Circuit_Chip_Optical.get(1),
                 GTModHandler.getModItem("eternalsingularity", "eternal_singularity", 1))
             .fluidInputs(Materials.Hydrogen.getPlasma(16000))
-            .itemOutputs(GTCMItemList.OpticalSOC.get(1), GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 1, 14))
+            .itemOutputs(GTCMItemList.OpticalSOC.get(16), GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 1, 14))
             .fluidOutputs(Materials.Helium.getPlasma(4000))
             .outputChances(10000, 1)
             .noOptimize()
@@ -131,7 +131,9 @@ public class PreciseHighEnergyPhotonicQuantumMasterRecipePool implements IRecipe
                 ItemList.Circuit_Chip_Optical.get(8),
                 GTModHandler.getModItem("eternalsingularity", "eternal_singularity", 1))
             .fluidInputs(Materials.Hydrogen.getPlasma(32000))
-            .itemOutputs(GTCMItemList.OpticalSOC.get(64), GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 8, 14))
+            .itemOutputs(
+                GTCMItemList.OpticalSOC.get(1024),
+                GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 8, 14))
             .fluidOutputs(Materials.Helium.getPlasma(8000))
             .outputChances(10000, 10)
             .noOptimize()
@@ -146,7 +148,7 @@ public class PreciseHighEnergyPhotonicQuantumMasterRecipePool implements IRecipe
                 ItemList.Circuit_Chip_Optical.get(2),
                 GTModHandler.getModItem("eternalsingularity", "eternal_singularity", 1))
             .fluidInputs(Materials.Hydrogen.getPlasma(16000))
-            .itemOutputs(GTCMItemList.OpticalSOC.get(6), GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 1, 14))
+            .itemOutputs(GTCMItemList.OpticalSOC.get(96), GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 1, 14))
             .fluidOutputs(Materials.Helium.getPlasma(4000))
             .outputChances(10000, 10)
             .noOptimize()
@@ -163,7 +165,7 @@ public class PreciseHighEnergyPhotonicQuantumMasterRecipePool implements IRecipe
                 GTModHandler.getModItem("eternalsingularity", "eternal_singularity", 1))
             .fluidInputs(Materials.Hydrogen.getPlasma(32000))
             .itemOutputs(
-                GTCMItemList.OpticalSOC.get(384),
+                GTCMItemList.OpticalSOC.get(6144),
                 GTModHandler.getModItem(GTPlusPlus.ID, "particleBase", 8, 14))
             .fluidOutputs(Materials.Helium.getPlasma(8000))
             .outputChances(10000, 1000)

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CircuitAssemblerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CircuitAssemblerRecipePool.java
@@ -1,5 +1,7 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 
+import static com.dreammaster.gthandler.CustomItemList.HighEnergyFlowCircuit;
+import static gregtech.api.enums.TierEU.RECIPE_LuV;
 import static gregtech.api.enums.TierEU.RECIPE_UIV;
 
 import com.Nxer.TwistSpaceTechnology.common.init.GTCMItemList;
@@ -13,6 +15,7 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.core.material.MaterialMisc;
+import gtPlusPlus.core.material.MaterialsAlloy;
 import tectech.thing.CustomItemList;
 
 public class CircuitAssemblerRecipePool implements IRecipePool {
@@ -22,18 +25,34 @@ public class CircuitAssemblerRecipePool implements IRecipePool {
 
         final IRecipeMap CA = RecipeMaps.circuitAssemblerRecipes;
 
-        // Optical Soc Circuit Assembly Line
+        // CA recipes will be multiplied during the initialization of bartworks,
+        // so it is better not to input more than 64/6 items too much.
 
+        // Optical Soc Circuit
         GTValues.RA.stdBuilder()
             .itemInputs(
-                ItemList.Circuit_Board_Optical.get(16),
+                ItemList.Circuit_Board_Optical.get(1),
                 GTCMItemList.OpticalSOC.get(1),
-                CustomItemList.DATApipe.get(16),
+                CustomItemList.DATApipe.get(1),
                 GTOreDictUnificator.get(OrePrefixes.bolt, Materials.Infinity, 3))
-            .fluidInputs(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(144 * 3))
-            .itemOutputs(ItemList.Circuit_OpticalProcessor.get(16))
+            .fluidInputs(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(144 * 4))
+            .itemOutputs(ItemList.Circuit_OpticalProcessor.get(1))
             .eut(RECIPE_UIV)
             .duration(20 * 60)
             .addTo(CA);
+
+        // High Energy Flow Circuit
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Circuit_Board_Multifiberglass_Elite.get(1),
+                ItemList.Energy_LapotronicOrb2.get(1),
+                ItemList.Circuit_Chip_QPIC.get(2),
+                GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Infinity, 2))
+            .fluidInputs(MaterialsAlloy.INDALLOY_140.getFluidStack(144 * 2))
+            .itemOutputs(HighEnergyFlowCircuit.get(1))
+            .eut(RECIPE_LuV)
+            .duration(20 * 60)
+            .addTo(CA);
+
     }
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
@@ -530,6 +530,17 @@ public class TstUtils {
     }
 
     /**
+     * Copy a new amount of a fluid stack
+     *
+     * @param aAmount the amount of new stack
+     * @param aStack  the target fluid stack
+     * @return new fluid stack
+     */
+    public static FluidStack copyAmountFluid(int aAmount, FluidStack aStack) {
+        return new FluidStack(aStack.getFluid(), aAmount);
+    }
+
+    /**
      * Return a shallow copy list of the array where the {@code null} elements are removed.
      *
      * @param array the array

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,6 +18,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -621,5 +623,38 @@ public class TstUtils {
             }
         }
         return newStack.toArray(new ItemStack[0]);
+    }
+
+
+    public static FluidStack[] mergeSameFluid(FluidStack[] fluidStacks) {
+
+        Map<Fluid, Integer> fluidMap = new LinkedHashMap<>();
+
+        for (FluidStack aStack : fluidStacks) {
+            fluidMap.put(aStack.getFluid(), fluidMap.getOrDefault(aStack.getFluid(), 0) + aStack.amount);
+        }
+
+        ArrayList<FluidStack> mergedList = new ArrayList<>();
+        for (Map.Entry<Fluid, Integer> entry : fluidMap.entrySet()) {
+            mergedList.add(new FluidStack(entry.getKey(), entry.getValue()));
+        }
+
+        return mergedList.toArray(new FluidStack[0]);
+    }
+
+    public static ItemStack[] mergeSameItem(ItemStack[] itemStacks) {
+
+        Map<Item, Integer> itemMap = new LinkedHashMap<>();
+
+        for (ItemStack aStack : itemStacks) {
+            itemMap.put(aStack.getItem(), itemMap.getOrDefault(aStack.getItem(), 0) + aStack.stackSize);
+        }
+
+        ArrayList<ItemStack> mergedList = new ArrayList<>();
+        for (Map.Entry<Item, Integer> entry : itemMap.entrySet()) {
+            mergedList.add(new ItemStack(entry.getKey(), entry.getValue()));
+        }
+
+        return mergedList.toArray(new ItemStack[0]);
     }
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/util/TstUtils.java
@@ -625,7 +625,6 @@ public class TstUtils {
         return newStack.toArray(new ItemStack[0]);
     }
 
-
     public static FluidStack[] mergeSameFluid(FluidStack[] fluidStacks) {
 
         Map<Fluid, Integer> fluidMap = new LinkedHashMap<>();


### PR DESCRIPTION
- 增加了光学soc在光学电路中的消耗，同时等额降低了光学soc的造价，并修改顶点配方为自动生成
  鉴于原版soc配方通常为一出多，如果假设奇点作为soc的核心材料，等效于生物之于海珀珍，故因而倍增。
![image](https://github.com/user-attachments/assets/0dde1edc-a8a4-4e53-b6da-854955093cc1)
![image](https://github.com/user-attachments/assets/b9ec155c-7ed5-4d74-b5ef-a6b6ffefea5a)

- 考虑到顶点新增的电装低电压配方，调整了高能量流电路的高级配方。
![image](https://github.com/user-attachments/assets/3d060f9c-b2e9-420b-b9ce-0e409b2bd793)
- 将湿件、生物处理单元的配方修改为自动生成
- 修复了顶点配方在生成时的bug：
  装配线自动生成配方的原始配方流体未翻倍
  无法自动处理的材料（主要是gtpp材料）存在异常调用的情况（TstUtil中的函数被移除）
  管道形式的材料没有被正常处理为流体
  

