### PR TITLE
Make all Loaders Static

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/ClientProxy.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/ClientProxy.java
@@ -26,8 +26,8 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         super.postInit(event);
-        new RendereLoader();
-        new SoundLoader();
+        RendereLoader.init();
+        SoundLoader.init();
     }
 
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/CommonProxy.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/CommonProxy.java
@@ -24,7 +24,6 @@ import com.Nxer.TwistSpaceTechnology.event.TickingEvent;
 import com.Nxer.TwistSpaceTechnology.loader.LazyStaticsInitLoader;
 import com.Nxer.TwistSpaceTechnology.loader.MachineLoader;
 import com.Nxer.TwistSpaceTechnology.loader.MaterialLoader;
-import com.Nxer.TwistSpaceTechnology.loader.OreDictLoader;
 import com.Nxer.TwistSpaceTechnology.loader.RecipeLoader;
 import com.Nxer.TwistSpaceTechnology.loader.TCLoader;
 import com.Nxer.TwistSpaceTechnology.network.TST_Network;
@@ -91,7 +90,7 @@ public class CommonProxy {
             new GTTextureBuilder().setFromBlock(ModBlocks.bloodRune, 0)
                 .build());
 
-        new LazyStaticsInitLoader().initStaticsOnInit();
+        LazyStaticsInitLoader.initStaticsOnInit();
         MachineLoader.loadMachines();
         GT_Hatch_RackComputationMonitor.run();
         EntityRegistry.registerModEntity(
@@ -103,7 +102,7 @@ public class CommonProxy {
             20,
             false);
 
-        new ModBlocksHandler().initStatics();
+        ModBlocksHandler.initStatics();
     }
 
     public void postInit(FMLPostInitializationEvent event) {
@@ -124,7 +123,6 @@ public class CommonProxy {
         }
 
         MachineLoader.loadMachinePostInit();
-        OreDictLoader.loadOreDictionary();
         RecipeLoader.loadRecipesPostInit();
 
         CropInfo.registerAllCropInfo();
@@ -132,10 +130,10 @@ public class CommonProxy {
         TCLoader.postInit();
     }
 
-    public void complete(FMLLoadCompleteEvent event) {
+    public static void complete(FMLLoadCompleteEvent event) {
         RecipeLoader.loadRecipes();
 
-        new LazyStaticsInitLoader().initStaticsOnCompleteInit();
+        LazyStaticsInitLoader.initStaticsOnCompleteInit();
     }
 
     public void serverStarting(FMLServerStartingEvent event) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/client/sound/SoundLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/client/sound/SoundLoader.java
@@ -8,7 +8,7 @@ public class SoundLoader {
 
     public static ResourceLocation BGM;
 
-    public SoundLoader() {
+    public static void init() {
         if (Config.Enable_PowerChairBGM) {
             BGM = new ResourceLocation("gtnhcommunitymod:PowerChair");
         }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/api/ModBlocksHandler.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/api/ModBlocksHandler.java
@@ -82,7 +82,7 @@ public final class ModBlocksHandler {
 
     // endregion
 
-    public void initStatics() {
+    public static void initStatics() {
         if (Mods.ThaumicBases.isModLoaded()) {
             Block crystalBlock = Block.getBlockFromName(Mods.ThaumicBases.ID + ":crystalBlock");
             AirCrystalBlock = Pair.of(crystalBlock, 0);

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/loader/LazyStaticsInitLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/loader/LazyStaticsInitLoader.java
@@ -11,11 +11,11 @@ import com.Nxer.TwistSpaceTechnology.system.DysonSphereProgram.machines.TST_Stra
 
 public class LazyStaticsInitLoader {
 
-    public void initStaticsOnInit() {
+    public static void initStaticsOnInit() {
         CheckRecipeResults.initStatics();
     }
 
-    public void initStaticsOnCompleteInit() {
+    public static void initStaticsOnCompleteInit() {
         MiscHelper.initStatics();
         TST_StrangeMatterAggregator.initStatics();
         TST_ArtificialStar.initStatics();

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/loader/OreDictLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/loader/OreDictLoader.java
@@ -1,8 +1,0 @@
-package com.Nxer.TwistSpaceTechnology.loader;
-
-public class OreDictLoader {
-
-    public static void loadOreDictionary() {
-
-    }
-}

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RecipeLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RecipeLoader.java
@@ -129,12 +129,12 @@ public class RecipeLoader {
         RapidHeatExchangeRecipePool.loadRecipes();
 
         SimpleFurnaceFuelPool.loadRecipes();
-        new TCResearches().register();
+        TCResearches.register();
 
         StaticMiscs.init();
         GT_TileEntity_MegaBrickedBlastFurnace.initStatics();
 
-        new OP_NormalProcessing().enumOreProcessingRecipes();
+        OP_NormalProcessing.enumOreProcessingRecipes();
 
         if (Config.Enable_MegaCraftingCenter) {
             new ExtremeCraftRecipeHandler().initECRecipe();
@@ -143,7 +143,7 @@ public class RecipeLoader {
     }
 
     public static void loadRecipesPostInit() {
-        new IntensifyChemicalDistorterRecipePool().loadRecipePostInit();
+        IntensifyChemicalDistorterRecipePool.loadRecipePostInit();
     }
 
     public static boolean hasLoadedRecipesServerStarted = false;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RecipeLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RecipeLoader.java
@@ -3,7 +3,6 @@ package com.Nxer.TwistSpaceTechnology.loader;
 import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.machine.GT_TileEntity_MegaBrickedBlastFurnace;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.recipe.commonRecipe.ShapedCraftRecipePool;
 import com.Nxer.TwistSpaceTechnology.recipe.commonRecipe.SimpleFurnaceFuelPool;
 import com.Nxer.TwistSpaceTechnology.recipe.craftRecipe.item.CardiganRecipes;
@@ -69,42 +68,67 @@ public class RecipeLoader {
     public static void loadRecipes() {
 
         // TODO Split GTCMMachineRecipes
-        IRecipePool[] craftRecipePool = {
-            // Item Recipes
-            new SingleItemRecipes(), new SingleBlockRecipes(), new CosmicProcessorCircuitRecipes(),
-            // Machine Recipes
-            new SingleMachineRecipes(), new TSTBufferedEnergyHatchRecipes(), new ModularHatchesRecipes(),
-            new TSTSolidifierHatchRecipes(), new GTCMMachineRecipes(), new CardiganRecipes() };
+        // Item Recipes
+        SingleItemRecipes.loadRecipes();
+        SingleBlockRecipes.loadRecipes();
+        CosmicProcessorCircuitRecipes.loadRecipes();
 
-        for (IRecipePool recipePool : craftRecipePool) {
-            recipePool.loadRecipes();
-        }
+        // Machine Recipes
+        SingleMachineRecipes.loadRecipes();
+        TSTBufferedEnergyHatchRecipes.loadRecipes();
+        ModularHatchesRecipes.loadRecipes();
 
-        IRecipePool[] machineRecipePools = new IRecipePool[] {
-            // Original GTNH RecipeMap
-            new ChemicalReactorRecipePool(), new CircuitAssemblerRecipePool(), new DistillationRecipePool(),
-            new ExtractorRecipePool(), new CompressorRecipePool(), new LanthanidesRecipePool(),
-            new CentrifugeRecipePool(), new ShapedCraftRecipePool(), new MixerRecipePool(), new QFTRecipePool(),
-            new NanoForgeRecipePool(), new FluidHeaterRecipePool(), new ParticleColliderRecipePool(),
-            new FusionReactorRecipePool(), new SpaceAssemblerRecipePool(), new TCRecipePool(),
-            new FluidSolidifierRecipePool(), new DragonBloodRecipe(), new DTPFRecipePool(),
-            // TST Recipe Map
-            new IntensifyChemicalDistorterRecipePool(), new PreciseHighEnergyPhotonicQuantumMasterRecipePool(),
-            new MiracleTopRecipePool(), new CrystallineInfinitierRecipePool(), new DSPRecipePool(),
-            new MegaUniversalSpaceStationRecipePool(), new StellarMaterialSiphonRecipePool(),
-            new AssemblyLineWithoutResearchRecipePool(), new BOTRecipePool(), new StarKernelForgeRecipePool(),
-            new ElvenWorkshopRecipePool(), new RuneEngraverRecipePool(), new CokingFactoryRecipePool(),
-            new StellarForgeRecipePool(), new HyperSpacetimeTransformerRecipePool(),
-            new AquaticZoneSimulatorFakeRecipe(), new NeutronActivatorWithEURecipePool(),
-            new MassFabricatorGenesisRecipePool(), new MicroSpaceTimeFabricatorioRecipePool(),
-            new BloodyHellRecipePool(), new MegaStoneBreakerRecipePool(), new IndustrialAlchemyTowerRecipePool(),
-            new CircuitAssemblyLineWithoutImprintRecipePool(), new RapidHeatExchangeRecipePool() };
+        TSTSolidifierHatchRecipes.loadRecipes();
+        GTCMMachineRecipes.loadRecipes();
+        CardiganRecipes.loadRecipes();
 
-        for (IRecipePool recipePool : machineRecipePools) {
-            recipePool.loadRecipes();
-        }
+        // Original GTNH RecipeMap
+        ChemicalReactorRecipePool.loadRecipes();
+        CircuitAssemblerRecipePool.loadRecipes();
+        DistillationRecipePool.loadRecipes();
+        ExtractorRecipePool.loadRecipes();
+        CompressorRecipePool.loadRecipes();
+        LanthanidesRecipePool.loadRecipes();
+        CentrifugeRecipePool.loadRecipes();
+        ShapedCraftRecipePool.loadRecipes();
+        MixerRecipePool.loadRecipes();
+        QFTRecipePool.loadRecipes();
+        NanoForgeRecipePool.loadRecipes();
+        FluidHeaterRecipePool.loadRecipes();
+        ParticleColliderRecipePool.loadRecipes();
+        FusionReactorRecipePool.loadRecipes();
+        SpaceAssemblerRecipePool.loadRecipes();
+        TCRecipePool.loadRecipes();
+        FluidSolidifierRecipePool.loadRecipes();
+        DragonBloodRecipe.loadRecipes();
+        DTPFRecipePool.loadRecipes();
+        // TST Recipe Map
+        IntensifyChemicalDistorterRecipePool.loadRecipes();
+        PreciseHighEnergyPhotonicQuantumMasterRecipePool.loadRecipes();
+        MiracleTopRecipePool.loadRecipes();
+        CrystallineInfinitierRecipePool.loadRecipes();
+        DSPRecipePool.loadRecipes();
+        MegaUniversalSpaceStationRecipePool.loadRecipes();
+        StellarMaterialSiphonRecipePool.loadRecipes();
+        AssemblyLineWithoutResearchRecipePool.loadRecipes();
+        BOTRecipePool.loadRecipes();
+        StarKernelForgeRecipePool.loadRecipes();
+        ElvenWorkshopRecipePool.loadRecipes();
+        RuneEngraverRecipePool.loadRecipes();
+        CokingFactoryRecipePool.loadRecipes();
+        StellarForgeRecipePool.loadRecipes();
+        HyperSpacetimeTransformerRecipePool.loadRecipes();
+        AquaticZoneSimulatorFakeRecipe.loadRecipes();
+        NeutronActivatorWithEURecipePool.loadRecipes();
+        MassFabricatorGenesisRecipePool.loadRecipes();
+        MicroSpaceTimeFabricatorioRecipePool.loadRecipes();
+        BloodyHellRecipePool.loadRecipes();
+        MegaStoneBreakerRecipePool.loadRecipes();
+        IndustrialAlchemyTowerRecipePool.loadRecipes();
+        CircuitAssemblyLineWithoutImprintRecipePool.loadRecipes();
+        RapidHeatExchangeRecipePool.loadRecipes();
 
-        new SimpleFurnaceFuelPool().loadRecipes();
+        SimpleFurnaceFuelPool.loadRecipes();
         new TCResearches().register();
 
         StaticMiscs.init();
@@ -131,10 +155,10 @@ public class RecipeLoader {
         }
         hasLoadedRecipesServerStarted = true;
 
-        new StellarForgeRecipePool().loadOnServerStarted();
-        new TreeGrowthSimulatorWithoutToolFakeRecipe().loadRecipes();
+        StellarForgeRecipePool.loadOnServerStarted();
+        TreeGrowthSimulatorWithoutToolFakeRecipe.loadRecipes();
         if (Config.Enable_IndustrialMagicMatrix) {
-            new IndustrialMagicMatrixRecipePool().loadRecipes();
+            IndustrialMagicMatrixRecipePool.loadRecipes();
         }
     }
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RendereLoader.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/loader/RendereLoader.java
@@ -17,7 +17,7 @@ public class RendereLoader {
     public static IModelCustom PowerChairModel = null;
     public static IModelCustom YamatoModel = null;
 
-    public RendereLoader() {
+    public static void init() {
         PowerChairModel = AdvancedModelLoader.loadModel(new ResourceLocation("gtnhcommunitymod:model/PowerChair.obj"));
         YamatoModel = AdvancedModelLoader.loadModel(new ResourceLocation("gtnhcommunitymod:model/Yamato.obj"));
         RendereLoader.registerItemRenderers();

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/IRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/IRecipePool.java
@@ -1,9 +1,0 @@
-package com.Nxer.TwistSpaceTechnology.recipe;
-
-public interface IRecipePool {
-
-    /**
-     * Called at RecipeLoader
-     */
-    void loadRecipes();
-}

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/commonRecipe/ShapedCraftRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/commonRecipe/ShapedCraftRecipePool.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import appeng.api.AEApi;
 import gregtech.api.enums.ItemList;
@@ -22,11 +21,9 @@ import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import wanion.avaritiaddons.block.extremeautocrafter.BlockExtremeAutoCrafter;
 
-public class ShapedCraftRecipePool implements IRecipePool {
+public class ShapedCraftRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         // Large Steam Forge Hammer
         addCraftingRecipe(
             GTCMItemList.LargeSteamForgeHammer.get(1),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/commonRecipe/SimpleFurnaceFuelPool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/commonRecipe/SimpleFurnaceFuelPool.java
@@ -9,9 +9,7 @@ import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
-import cpw.mods.fml.common.IFuelHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 /**
@@ -20,7 +18,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
  *
  * @author Nxer
  */
-public class SimpleFurnaceFuelPool implements IRecipePool, IFuelHandler {
+public class SimpleFurnaceFuelPool {
 
     public static final Map<Pair<Item, Integer>, Integer> fuelMap = new HashMap<>();
 
@@ -37,18 +35,16 @@ public class SimpleFurnaceFuelPool implements IRecipePool, IFuelHandler {
     /**
      * Registry your item burnable here.
      */
-    public void registryFuels() {
+    public static void registryFuels() {
         setFuel(GTCMItemList.EnergyShard.get(1), 365 * 24 * 3600 * 20);
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         registryFuels();
-        GameRegistry.registerFuelHandler(this);
+        GameRegistry.registerFuelHandler(fuel -> getBurnTime(fuel));
     }
 
-    @Override
-    public int getBurnTime(ItemStack fuel) {
+    public static int getBurnTime(ItemStack fuel) {
         if (fuel == null || fuel.getItem() == null) return 0;
 
         return fuelMap.getOrDefault(Pair.of(fuel.getItem(), fuel.getItemDamage()), 0);

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/CardiganRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/CardiganRecipes.java
@@ -4,15 +4,13 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.item.ItemCardigan;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.util.GTModHandler;
 
-public class CardiganRecipes implements IRecipePool {
+public class CardiganRecipes {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         GTModHandler.addCraftingRecipe(
             ItemCardigan.CardiganULV,
             new Object[] { "W W", "WWW", "WWW", 'W', new ItemStack(Blocks.wool), });

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/CosmicProcessorCircuitRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/CosmicProcessorCircuitRecipes.java
@@ -29,7 +29,6 @@ import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
 
@@ -51,11 +50,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.item.ModItems;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 
-public class CosmicProcessorCircuitRecipes implements IRecipePool {
+public class CosmicProcessorCircuitRecipes {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final ItemStack eternal_singularity = GTModHandler.getModItem("eternalsingularity", "eternal_singularity", 1);
 
         // Silicon Neutron to UHV circuits

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/SingleBlockRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/SingleBlockRecipes.java
@@ -5,7 +5,6 @@ import static gregtech.api.util.GTModHandler.addCraftingRecipe;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import goodgenerator.api.recipe.GoodGeneratorRecipeMaps;
@@ -19,21 +18,10 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.core.material.MaterialsElements;
 
-public class SingleBlockRecipes implements IRecipePool {
+public class SingleBlockRecipes {
 
     // spotless:off
-    @Override
-    public void loadRecipes() {
-        loadTTBlockRecipes();
-        loadGTBlockRecipes();
-        loadTSTBlockRecipes();
-    }
-
-    void loadTTBlockRecipes() {}
-
-    void loadGTBlockRecipes() {}
-
-    void loadTSTBlockRecipes() {
+    public static void loadRecipes() {
         // Borophene Based Nanowire Composite Thermal Conductive Casing
         TST_RecipeBuilder.builder()
             .itemInputs(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/SingleItemRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/item/SingleItemRecipes.java
@@ -4,7 +4,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
 
@@ -21,11 +20,10 @@ import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
 
-public class SingleItemRecipes implements IRecipePool {
+public class SingleItemRecipes {
 
     // spotless:off
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         // Borophene Foil
         TST_RecipeBuilder.builder()
             .itemInputs(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/GTCMMachineRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/GTCMMachineRecipes.java
@@ -178,7 +178,6 @@ import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.BloodyHellTierKey;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.BloodMagicHelper;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.gtnewhorizons.gtnhintergalactic.block.IGBlocks;
@@ -229,10 +228,9 @@ import tectech.thing.casing.TTCasingsContainer;
 
 @Deprecated
 @SuppressWarnings("SpellCheckingInspection")
-public class GTCMMachineRecipes implements IRecipePool {
+public class GTCMMachineRecipes {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TwistSpaceTechnology.LOG.info("GTCMMachineRecipePool loading recipes.");
 
         Fluid solderIndAlloy = FluidRegistry.getFluid("molten.indalloy140");

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/ModularHatchesRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/ModularHatchesRecipes.java
@@ -18,7 +18,6 @@ import net.minecraft.item.ItemStack;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
 
@@ -35,14 +34,13 @@ import gtPlusPlus.core.material.MaterialMisc;
 import gtPlusPlus.core.material.MaterialsElements;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
-public class ModularHatchesRecipes implements IRecipePool {
+public class ModularHatchesRecipes {
 
-    private long getRecipeVoltageFromModuleTier(int t) {
+    private static long getRecipeVoltageFromModuleTier(int t) {
         return VP[7 + t];
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if (!Config.EnableModularizedMachineSystem) return;
 
         Materials[] materials = new Materials[] { Materials.NaquadahAlloy, Materials.Neutronium,

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/SingleMachineRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/SingleMachineRecipes.java
@@ -9,7 +9,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.api.ModItemHandler;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import goodgenerator.util.ItemRefer;
 import gregtech.api.enums.ItemList;
@@ -19,11 +18,10 @@ import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import tectech.recipe.TTRecipeAdder;
 
-public class SingleMachineRecipes implements IRecipePool {
+public class SingleMachineRecipes {
 
     // spotless:off
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if(Config.Enable_HyperThermalConvector) {
             TTRecipeAdder.addResearchableAssemblylineRecipe(
                 ItemRefer.Extreme_Heat_Exchanger.get(1),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/TSTBufferedEnergyHatchRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/TSTBufferedEnergyHatchRecipes.java
@@ -31,7 +31,6 @@ import static com.dreammaster.gthandler.GT_Loader_Machines.bitsd;
 import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -42,11 +41,9 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 
-public class TSTBufferedEnergyHatchRecipes implements IRecipePool {
+public class TSTBufferedEnergyHatchRecipes {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final ItemStack[] circuits = new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1),
             GTOreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 1),
             GTOreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/TSTSolidifierHatchRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/TSTSolidifierHatchRecipes.java
@@ -8,7 +8,6 @@ import static gregtech.api.enums.TierEU.RECIPE_ZPM;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import bartworks.system.material.WerkstoffLoader;
@@ -19,10 +18,9 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsAlloy;
 
-public class TSTSolidifierHatchRecipes implements IRecipePool {
+public class TSTSolidifierHatchRecipes {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TST_RecipeBuilder.builder()
             .itemInputs(
                 GTUtility.getIntegratedCircuit(18),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/AssemblyLineWithoutResearchRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/AssemblyLineWithoutResearchRecipePool.java
@@ -58,7 +58,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.TstUtils;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
@@ -86,9 +85,9 @@ import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtnhlanth.common.register.LanthItemList;
 import wanion.avaritiaddons.block.chest.infinity.BlockInfinityChest;
 
-public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
+public class AssemblyLineWithoutResearchRecipePool {
 
-    public ItemStack transToWildCircuit(ItemStack items) {
+    public static ItemStack transToWildCircuit(ItemStack items) {
         ItemData tPrefixMaterial = GTOreDictUnificator.getAssociation(items);
 
         if (tPrefixMaterial == null || !tPrefixMaterial.hasValidPrefixMaterialData()) return null;
@@ -118,8 +117,7 @@ public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
         return result;
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TwistSpaceTechnology.LOG.info("Loading Mega Assembly Line Recipes.");
 
         // skip these recipes
@@ -243,7 +241,7 @@ public class AssemblyLineWithoutResearchRecipePool implements IRecipePool {
         // .size());
     }
 
-    public void loadSpecialRecipes() {
+    public static void loadSpecialRecipes() {
         final RecipeMap<?> MASL = GTCMRecipe.AssemblyLineWithoutResearchRecipe;
         final Fluid solderUEV = FluidRegistry.getFluid("molten.mutatedlivingsolder") != null
             ? FluidRegistry.getFluid("molten.mutatedlivingsolder")

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BOTRecipe/BOTRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BOTRecipe/BOTRecipePool.java
@@ -2,17 +2,15 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.expanded.BOTRecipe;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.OrePrefixes;
 import ic2.api.item.IC2Items;
 import vazkii.botania.api.BotaniaAPI;
 
-public class BOTRecipePool implements IRecipePool {
+public class BOTRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         BotaniaAPI.elvenTradeRecipes.add(
             new ElvenTradeRecipe(
                 GTCMItemList.PurpleMagnoliaSapling.get(1),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BOTRecipe/RuneEngraverRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BOTRecipe/RuneEngraverRecipePool.java
@@ -7,7 +7,6 @@ import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -17,10 +16,9 @@ import gregtech.api.util.GTUtility;
 import vazkii.botania.common.item.ModItems;
 
 // spotless:off
-public class RuneEngraverRecipePool implements IRecipePool {
+public class RuneEngraverRecipePool  {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap RE=GTCMRecipe.RuneEngraverRecipes;
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BloodyHellRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/BloodyHellRecipePool.java
@@ -6,7 +6,6 @@ import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.BloodyHellAlchemicTierKey;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.BloodyHellTierKey;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.BloodMagicHelper;
 import com.Nxer.TwistSpaceTechnology.util.TSTArrayUtils;
 
@@ -20,9 +19,9 @@ import WayofTime.alchemicalWizardry.api.bindingRegistry.BindingRegistry;
 import gregtech.api.enums.GTValues;
 import gregtech.api.util.GTUtility;
 
-public class BloodyHellRecipePool implements IRecipePool {
+public class BloodyHellRecipePool {
 
-    public void loadRecipes() {
+    public static void loadRecipes() {
         // total(Life Essence, L) / soakingSpeed(L/tick) = duration(tick)
         // for example, a recipe costs 1,000L of LE, it should take 10 ticks to craft
         var soakingSpeed = 10;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CircuitAssemblyLineWithoutImprintRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CircuitAssemblyLineWithoutImprintRecipePool.java
@@ -14,7 +14,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.rewrites.TST_ItemID;
 
 import bartworks.util.BWUtil;
@@ -30,10 +29,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialMisc;
 import gtPlusPlus.core.material.MaterialsAlloy;
 
-public class CircuitAssemblyLineWithoutImprintRecipePool implements IRecipePool {
+public class CircuitAssemblyLineWithoutImprintRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TST_ItemID IC2_Circuit = TST_ItemID
             .create(GTModHandler.getModItem(Mods.IndustrialCraft2.ID, "itemPartCircuit", 1));
         TST_ItemID IC2_AdvCircuit = TST_ItemID
@@ -71,7 +69,7 @@ public class CircuitAssemblyLineWithoutImprintRecipePool implements IRecipePool 
     }
 
     // Modify the circuit part to warp, others turn 16 times.
-    public ItemStack[] ModifyInput(ItemStack[] input) {
+    public static ItemStack[] ModifyInput(ItemStack[] input) {
         if (!(input != null && input.length > 0)) return new ItemStack[0];
         ArrayList<ItemStack> inputItems = new ArrayList<>();
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CokingFactoryRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CokingFactoryRecipePool.java
@@ -7,7 +7,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -15,10 +14,9 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 
-public class CokingFactoryRecipePool implements IRecipePool {
+public class CokingFactoryRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap coke = GTCMRecipe.CokingFactoryRecipes;
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CrystallineInfinitierRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/CrystallineInfinitierRecipePool.java
@@ -18,7 +18,6 @@ import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.dreammaster.gthandler.CustomItemList;
 
 import bartworks.system.material.WerkstoffLoader;
@@ -34,10 +33,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class CrystallineInfinitierRecipePool implements IRecipePool {
+public class CrystallineInfinitierRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap AC = RecipeMaps.autoclaveRecipes;
         final IRecipeMap LE = RecipeMaps.laserEngraverRecipes;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/DSPRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/DSPRecipePool.java
@@ -58,7 +58,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
@@ -84,7 +83,7 @@ import gtPlusPlus.core.material.Particle;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 
-public class DSPRecipePool implements IRecipePool {
+public class DSPRecipePool {
 
     private static ItemStack appendToItemStackDisplayName(ItemStack itemStack, String extra) {
         String originName = itemStack.getDisplayName();
@@ -94,8 +93,7 @@ public class DSPRecipePool implements IRecipePool {
         return itemStack;
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap DSPLauncherRecipe = GTCMRecipe.DSP_LauncherRecipes;
         final IRecipeMap SpaceAssembler = IGRecipeMaps.spaceAssemblerRecipes;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/AquaticZoneSimulatorFakeRecipe.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/AquaticZoneSimulatorFakeRecipe.java
@@ -18,23 +18,21 @@ import org.apache.logging.log4j.Logger;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.util.GTModHandler;
 
-public class AquaticZoneSimulatorFakeRecipe implements IRecipePool {
+public class AquaticZoneSimulatorFakeRecipe {
 
     private static final Logger LOGGER = LogManager.getLogger(AquaticZoneSimulatorFakeRecipe.class);
     static FluidStack WaterStack = Materials.Water.getFluid(10000);
-    ItemStack Offspring = GTCMItemList.OffSpring.get(1);
+    private static final ItemStack Offspring = GTCMItemList.OffSpring.get(1);
     public static ArrayList<ItemStack> WatersOutputs = new ArrayList<>();
     public static HashMap<String, Integer> WatersChances = new HashMap<>();
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         initStatics();
         loadAquaticZoneFakeRecipes();
         loadAquaticZoneTrueRecipes();
@@ -42,7 +40,7 @@ public class AquaticZoneSimulatorFakeRecipe implements IRecipePool {
 
     private static List<WeightedRandomFishable> cachedFishList = null;
 
-    void initStatics() {
+    static void initStatics() {
         // generate fishes
         List<WeightedRandomFishable> fishList = getFishList();
 
@@ -105,7 +103,7 @@ public class AquaticZoneSimulatorFakeRecipe implements IRecipePool {
         return cachedFishList;
     }
 
-    void loadAquaticZoneFakeRecipes() {
+    static void loadAquaticZoneFakeRecipes() {
         for (ItemStack aStack : WatersOutputs) {
             ItemStack Input = aStack.copy();
             Input.stackSize = 0;
@@ -114,7 +112,7 @@ public class AquaticZoneSimulatorFakeRecipe implements IRecipePool {
         }
     }
 
-    void loadAquaticZoneTrueRecipes() {
+    static void loadAquaticZoneTrueRecipes() {
         // generate recipe chance
         int TotalSize = 0;
         for (ItemStack aStack : WatersOutputs) TotalSize += aStack.stackSize;
@@ -127,7 +125,7 @@ public class AquaticZoneSimulatorFakeRecipe implements IRecipePool {
         WatersChances.put(getItemStackString(Offspring), 1);
     }
 
-    void addFakeRecipe(ItemStack inputStacks, ItemStack outputStacks, FluidStack inputFluid) {
+    static void addFakeRecipe(ItemStack inputStacks, ItemStack outputStacks, FluidStack inputFluid) {
         GTValues.RA.stdBuilder()
             .itemInputs(inputStacks)
             .itemOutputs(outputStacks)

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/Mode3SimulatorFakeRecipe.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/Mode3SimulatorFakeRecipe.java
@@ -27,7 +27,7 @@
 // import static kubatech.tileentity.gregtech.multiblock.GT_MetaTileEntity_ExtremeEntityCrusher.DIAMOND_SPIKES_DAMAGE;
 // import static kubatech.tileentity.gregtech.multiblock.GT_MetaTileEntity_ExtremeEntityCrusher.MOB_SPAWN_INTERVAL;
 //
-// public class Mode3SimulatorFakeRecipe extends MobHandlerLoader implements IRecipePool{
+// public class Mode3SimulatorFakeRecipe extends MobHandlerLoader {
 // private static MobHandlerLoader instance = null;
 // public static Map<String, MobEECRecipe> MobrecipeMap = new HashMap<>();
 //

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/TreeGrowthSimulatorWithoutToolFakeRecipe.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/EcoSphereFakeRecipes/TreeGrowthSimulatorWithoutToolFakeRecipe.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 
 import galaxyspace.BarnardsSystem.BRFluids;
@@ -28,7 +27,7 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.MTETreeFarm.Mode;
 
-public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
+public class TreeGrowthSimulatorWithoutToolFakeRecipe {
 
     static FluidStack WaterStack = Materials.Water.getFluid(1000);
     static FluidStack UnknowWaterStack = new FluidStack(BRFluids.UnknowWater, 1000);
@@ -46,14 +45,13 @@ public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
     static ItemStack[] allFruits;
     public static ItemStack[][] allProducts;
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         initStatic();
         loadTreeFarmWithoutToolRecipe();
         loadManualRecipes();
     }
 
-    void initStatic() {
+    static void initStatic() {
         ArrayList<ItemStack> allSaplingsInCopy = new ArrayList<>();
         EnumMap<Mode, ArrayList<ItemStack>> allProductsMap = new EnumMap<>(Mode.class);
 
@@ -112,13 +110,13 @@ public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
         allProducts = new ItemStack[][] { allLogs, allSaplings, allLeaves, allFruits };
     }
 
-    void loadTreeFarmWithoutToolRecipe() {
+    static void loadTreeFarmWithoutToolRecipe() {
         for (ItemStack Sapling : allSaplingsIn) {
             addFakeRecipe(Sapling, new ItemStack[] { Sapling }, WaterStack);
         }
     }
 
-    void loadManualRecipes() {
+    static void loadManualRecipes() {
         // Barnarda C
         if (Mods.GalaxySpace.isModLoaded()) addSpecialFakeRecipe(
             GTModHandler.getModItem(Mods.GalaxySpace.ID, "barnardaCsapling", 0, 1),
@@ -178,11 +176,11 @@ public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
         tag.setTag("ench", enchantments);
     }
 
-    void addSpecialFakeRecipe(ItemStack SpecialSapling, FluidStack SpecialFluid) {
+    static void addSpecialFakeRecipe(ItemStack SpecialSapling, FluidStack SpecialFluid) {
         addFakeRecipe(SpecialSapling, allSaplingWithTag, SpecialFluid);
     }
 
-    void addFakeRecipe(ItemStack Sapling, ItemStack[] specialStacks, FluidStack inputFluid) {
+    static void addFakeRecipe(ItemStack Sapling, ItemStack[] specialStacks, FluidStack inputFluid) {
         EnumMap<Mode, ItemStack> ProductMap = queryTreeProduct(Sapling);
 
         // ItemStack[] inputStacks = new ItemStack[Mode.values().length];
@@ -213,7 +211,7 @@ public class TreeGrowthSimulatorWithoutToolFakeRecipe implements IRecipePool {
         addFakeRecipe(i, o, specialStacks, inputFluid);
     }
 
-    void addFakeRecipe(ItemStack[] inputStacks, ItemStack[] outputStacks, ItemStack[] specialStacks,
+    static void addFakeRecipe(ItemStack[] inputStacks, ItemStack[] outputStacks, ItemStack[] specialStacks,
         FluidStack inputFluid) {
         GTValues.RA.stdBuilder()
             .itemInputs(inputStacks)

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/ElvenWorkshopRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/ElvenWorkshopRecipePool.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -20,10 +19,9 @@ import vazkii.botania.common.block.ModFluffBlocks;
 import vazkii.botania.common.item.ModItems;
 
 // spotless:off
-public class ElvenWorkshopRecipePool implements IRecipePool {
+public class ElvenWorkshopRecipePool  {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap EW = GTCMRecipe.ElvenWorkshopRecipes;
         //terrastrial recipe

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/HyperSpacetimeTransformerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/HyperSpacetimeTransformerRecipePool.java
@@ -4,7 +4,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -12,10 +11,9 @@ import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IRecipeMap;
 
 // spotless:off
-public class HyperSpacetimeTransformerRecipePool implements IRecipePool {
+public class HyperSpacetimeTransformerRecipePool  {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final IRecipeMap HST = GTCMRecipe.HyperSpacetimeTransformerRecipe;
         //terrastrial recipe

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IndustrialAlchemyTowerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IndustrialAlchemyTowerRecipePool.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import net.minecraft.item.ItemStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.system.Thaumcraft.TCRecipeTools;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 
@@ -19,10 +18,9 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.util.GTUtility;
 import thaumcraft.common.items.ItemEssence;
 
-public class IndustrialAlchemyTowerRecipePool implements IRecipePool {
+public class IndustrialAlchemyTowerRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TCRecipeTools.getCrucibleCraftingRecipe();
         final IRecipeMap IIA = GTCMRecipe.IndustrialAlchemyTowerRecipes;
         for (Map.Entry<String, ArrayList<TCRecipeTools.CrucibleCraftingRecipe>> entry : TCRecipeTools.CCR.entrySet()) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IndustrialMagicMatrixRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IndustrialMagicMatrixRecipePool.java
@@ -18,7 +18,6 @@ import net.minecraft.item.ItemStack;
 import com.Nxer.TwistSpaceTechnology.common.api.ModBlocksHandler;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.IndustrialMagicMatrixRecipeIndexKey;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.system.Thaumcraft.TCRecipeTools;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 
@@ -31,11 +30,11 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 import thaumcraft.common.items.ItemEssence;
 
-public class IndustrialMagicMatrixRecipePool implements IRecipePool {
+public class IndustrialMagicMatrixRecipePool {
 
-    protected ItemStack[] itemsUnconsumed = new ItemStack[] { new ItemStack(bigPearl) };
+    protected static ItemStack[] itemsUnconsumed = new ItemStack[] { new ItemStack(bigPearl) };
 
-    protected ItemStack[] checkInputSpecial(ItemStack... itemStacks) {
+    protected static ItemStack[] checkInputSpecial(ItemStack... itemStacks) {
         baseLoop: for (ItemStack i : itemStacks) {
             for (ItemStack u : itemsUnconsumed) {
                 if (GTUtility.areStacksEqual(i, u)) {
@@ -47,9 +46,9 @@ public class IndustrialMagicMatrixRecipePool implements IRecipePool {
         return itemStacks;
     }
 
-    protected Set<Item> skips;
+    protected static Set<Item> skips;
 
-    protected boolean shouldSkip(Item item) {
+    protected static boolean shouldSkip(Item item) {
         if (null == skips) {
             skips = new HashSet<>();
             skips.add(itemJarNode);
@@ -70,8 +69,7 @@ public class IndustrialMagicMatrixRecipePool implements IRecipePool {
         return skips.contains(item);
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TCRecipeTools.getInfusionCraftingRecipe();
 
         final IRecipeMap IIM = GTCMRecipe.IndustrialMagicMatrixRecipe;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IntensifyChemicalDistorterRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IntensifyChemicalDistorterRecipePool.java
@@ -16,7 +16,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.dreammaster.gthandler.CustomItemList;
 
@@ -35,13 +34,12 @@ import gtPlusPlus.core.item.chemistry.GenericChem;
 import gtPlusPlus.core.material.MaterialMisc;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class IntensifyChemicalDistorterRecipePool implements IRecipePool {
+public class IntensifyChemicalDistorterRecipePool {
 
-    final RecipeMap<?> ICD = GTCMRecipe.IntensifyChemicalDistorterRecipes;
+    private static final RecipeMap<?> ICD = GTCMRecipe.IntensifyChemicalDistorterRecipes;
 
     // spotless:off
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         TwistSpaceTechnology.LOG.info("IntensifyChemicalDistorterRecipePool loading recipes.");
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IntensifyChemicalDistorterRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/IntensifyChemicalDistorterRecipePool.java
@@ -1018,7 +1018,7 @@ public class IntensifyChemicalDistorterRecipePool {
         // endregion
 
     }
-    public void loadRecipePostInit() {
+    public static void loadRecipePostInit() {
         // region H2O2
         GTValues.RA
             .stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MassFabricatorGenesisRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MassFabricatorGenesisRecipePool.java
@@ -1,16 +1,14 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.expanded;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.util.GTUtility;
 
-public class MassFabricatorGenesisRecipePool implements IRecipePool {
+public class MassFabricatorGenesisRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
             .fluidOutputs(Materials.UUMatter.getFluid(1000))

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MegaStoneBreakerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MegaStoneBreakerRecipePool.java
@@ -5,7 +5,6 @@ import static com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe.MegaSton
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import gregtech.api.enums.Materials;
@@ -15,36 +14,35 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 
-public class MegaStoneBreakerRecipePool implements IRecipePool {
+public class MegaStoneBreakerRecipePool {
 
-    ItemStack CobbleStone = new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone1 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone = new ItemStack(Blocks.cobblestone);
+    private static final ItemStack CobbleStone1 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 0)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone2 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone2 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 1)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone3 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone3 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 2)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone4 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone4 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 3)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone5 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone5 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 4)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone6 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone6 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 5)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone7 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone7 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 6)
         : new ItemStack(Blocks.cobblestone);
-    ItemStack CobbleStone8 = Mods.ExtraUtilities.isModLoaded()
+    private static final ItemStack CobbleStone8 = Mods.ExtraUtilities.isModLoaded()
         ? GTModHandler.getModItem(Mods.ExtraUtilities.ID, "cobblestone_compressed", 1, 7)
         : new ItemStack(Blocks.cobblestone);
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TST_RecipeBuilder.builder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(CobbleStone)

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MegaUniversalSpaceStationRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MegaUniversalSpaceStationRecipePool.java
@@ -11,7 +11,6 @@ import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.dreammaster.gthandler.CustomItemList;
 
 import bartworks.system.material.Werkstoff;
@@ -25,7 +24,7 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.util.GTRecipeConstants;
 import gregtech.api.util.GTUtility;
 
-public class MegaUniversalSpaceStationRecipePool implements IRecipePool {
+public class MegaUniversalSpaceStationRecipePool {
 
     final IRecipeMap stationRecipe = GTCMRecipe.megaUniversalSpaceStationRecipePool;
     static final IRecipeMap MT = GTCMRecipe.MiracleTopRecipes;
@@ -96,8 +95,7 @@ public class MegaUniversalSpaceStationRecipePool implements IRecipePool {
 
     // endregion
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if (Config.activateMegaSpaceStation) {
             spaceStationStructureBlock = new ItemStack[] { GTCMItemList.spaceStationStructureBlockLV.get(1),
                 GTCMItemList.spaceStationStructureBlockMV.get(1), GTCMItemList.spaceStationStructureBlockHV.get(1),
@@ -129,7 +127,7 @@ public class MegaUniversalSpaceStationRecipePool implements IRecipePool {
 
     }
 
-    public void loadCircuitRecipe() {
+    public static void loadCircuitRecipe() {
 
         // region umv
         var processor = uevPlusCircuit[4].copy();
@@ -590,7 +588,7 @@ public class MegaUniversalSpaceStationRecipePool implements IRecipePool {
 
     // this method loads recipe for recipe that not use MUSS but related to MUSS, eg, structure blocks and controller
     // blocks recipes.
-    public void loadOriginalRecipeForConstruct() {
+    public static void loadOriginalRecipeForConstruct() {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 ItemList.Circuit_OpticalMainframe.get(64),

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MicroSpaceTimeFabricatorioRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MicroSpaceTimeFabricatorioRecipePool.java
@@ -8,7 +8,6 @@ import static gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList.Laser_Lens_Spe
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import gregtech.api.enums.ItemList;
@@ -20,10 +19,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsElements;
 import gtPlusPlus.core.material.Particle;
 
-public class MicroSpaceTimeFabricatorioRecipePool implements IRecipePool {
+public class MicroSpaceTimeFabricatorioRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         // region Tesseract adv recipe
         TST_RecipeBuilder.builder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/MiracleTopRecipePool.java
@@ -34,7 +34,6 @@ import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.Nxer.TwistSpaceTechnology.util.rewrites.TST_ItemID;
 import com.dreammaster.gthandler.CustomItemList;
@@ -57,16 +56,15 @@ import gtPlusPlus.core.material.Material;
 import gtPlusPlus.core.material.MaterialsElements;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
-public class MiracleTopRecipePool implements IRecipePool {
+public class MiracleTopRecipePool {
 
-    final RecipeMap<?> MT = GTCMRecipe.MiracleTopRecipes;
+    private static final RecipeMap<?> MT = GTCMRecipe.MiracleTopRecipes;
     public static final HashMap<ItemStack, ItemStack> circuitItemsToWrapped = new HashMap<>();
-    public final HashSet<Materials> superConductorMaterialList = new HashSet<>();
-    public final HashSet<OrePrefixes> targetModifyOreDict = new HashSet<>();
-    public final HashMap<ItemStack, FluidStack> specialMaterialCantAutoModify = new HashMap<>();
+    private static final HashSet<Materials> superConductorMaterialList = new HashSet<>();
+    private static final HashSet<OrePrefixes> targetModifyOreDict = new HashSet<>();
+    private static final HashMap<ItemStack, FluidStack> specialMaterialCantAutoModify = new HashMap<>();
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         TwistSpaceTechnology.LOG.info("MiracleTopRecipePool loading recipes.");
         initStatics();
         loadCircuitAssemblerRecipes();
@@ -75,7 +73,7 @@ public class MiracleTopRecipePool implements IRecipePool {
         loadCustomRecipes();
     }
 
-    private void loadCircuitAssemblerRecipes() {
+    private static void loadCircuitAssemblerRecipes() {
         HashSet<TST_ItemID> IgnoreRecipeOutputs = new HashSet<>();
 
         IgnoreRecipeOutputs
@@ -158,7 +156,7 @@ public class MiracleTopRecipePool implements IRecipePool {
 
     }
 
-    private void loadAssemblyLineRecipes() {
+    private static void loadAssemblyLineRecipes() {
         HashSet<TST_ItemID> GenerateRecipeOutputs = new HashSet<>();
         GenerateRecipeOutputs.add(TST_ItemID.createNoNBT(ItemList.Circuit_Wetwaremainframe.get(1)));
         GenerateRecipeOutputs.add(TST_ItemID.createNoNBT(ItemList.Circuit_Biowaresupercomputer.get(1)));
@@ -323,7 +321,7 @@ public class MiracleTopRecipePool implements IRecipePool {
         }
     }
 
-    private void loadSpaceAssemblerRecipes() {
+    private static void loadSpaceAssemblerRecipes() {
         HashSet<TST_ItemID> GenerateRecipeOutputs = new HashSet<>();
         GenerateRecipeOutputs.add(TST_ItemID.createNoNBT(GTModHandler.getModItem("OpenComputers", "item", 1, 39)));
         GenerateRecipeOutputs.add(TST_ItemID.createNoNBT(ItemList.Optically_Perfected_CPU.get(1)));
@@ -337,7 +335,7 @@ public class MiracleTopRecipePool implements IRecipePool {
     }
 
     // Modify the circuit part to warp, others turn 16 times. All Material to molten.
-    public GTRecipe ModifyRecipe(GTRecipe baseRecipe, boolean isFluidInputMultiply) {
+    public static GTRecipe ModifyRecipe(GTRecipe baseRecipe, boolean isFluidInputMultiply) {
 
         ArrayList<ItemStack> inputItems = new ArrayList<>();
         ArrayList<FluidStack> inputFluids = new ArrayList<>();
@@ -411,7 +409,7 @@ public class MiracleTopRecipePool implements IRecipePool {
             0);
     }
 
-    public GTRecipe reduplicateRecipe(GTRecipe oRecipe, int inputItemMultiTimes, int inputFluidMultiTimes,
+    public static GTRecipe reduplicateRecipe(GTRecipe oRecipe, int inputItemMultiTimes, int inputFluidMultiTimes,
         int outputItemMultiTimes, int outputFluidMultiTimes, int eutMultiTimes, int durationMultiTimes) {
         ArrayList<ItemStack> inputItems = new ArrayList<>();
         ArrayList<FluidStack> inputFluids = new ArrayList<>();
@@ -447,11 +445,11 @@ public class MiracleTopRecipePool implements IRecipePool {
             0);
     }
 
-    public GTRecipe reduplicateRecipe(GTRecipe oRecipe, int n, int eut) {
+    public static GTRecipe reduplicateRecipe(GTRecipe oRecipe, int n, int eut) {
         return reduplicateRecipe(oRecipe, n, n, n, n, eut, n);
     }
 
-    public GTRecipe addIntegratedCircuitToRecipe(GTRecipe oRecipe, int circuitNum) {
+    public static GTRecipe addIntegratedCircuitToRecipe(GTRecipe oRecipe, int circuitNum) {
         ArrayList<ItemStack> inputItems = new ArrayList<>();
         inputItems.add(GTUtility.getIntegratedCircuit(circuitNum));
 
@@ -514,7 +512,7 @@ public class MiracleTopRecipePool implements IRecipePool {
         return mergedList.toArray(new ItemStack[0]);
     }
 
-    private void addRecipeMT(GTRecipe aRecipe) {
+    private static void addRecipeMT(GTRecipe aRecipe) {
         if (aRecipe == null) return;
         TST_RecipeBuilder.builder()
             .itemInputs(aRecipe.mInputs)
@@ -526,13 +524,13 @@ public class MiracleTopRecipePool implements IRecipePool {
             .addTo(MT);
     }
 
-    private void initStatics() {
+    private static void initStatics() {
 
         /**
          * init Wrap circuit parts
          */
         // spotless:off
-        ItemStack[] CircuitParts = new ItemStack[] {
+        ItemStack[] CircuitParts = new ItemStack[]{
             GTOreDictUnificator.get(OrePrefixes.circuit, Materials.ULV, 1),
             GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LV, 1),
             GTOreDictUnificator.get(OrePrefixes.circuit, Materials.MV, 1),
@@ -612,7 +610,7 @@ public class MiracleTopRecipePool implements IRecipePool {
             ItemList.Optical_Cpu_Containment_Housing.get(1),
             ItemList.Optically_Compatible_Memory.get(1),
             ItemList.Circuit_Parts_Crystal_Chip_Wetware.get(1),
-            ItemList.Circuit_Parts_Chip_Bioware.get(1) };
+            ItemList.Circuit_Parts_Chip_Bioware.get(1)};
 
         int Count = 0;
         for (WrappedCircuitItem item : WrappedCircuitItem.values()) {
@@ -727,12 +725,12 @@ public class MiracleTopRecipePool implements IRecipePool {
     }
 
     // spotless:off
-    public void loadCustomRecipes(){
+    public static void loadCustomRecipes() {
         // Do Not Add Messy Recipe to MT
 
-        final ItemStack ringBlock = GTModHandler.getModItem("SGCraft", "stargateRing" , 1, 0);
+        final ItemStack ringBlock = GTModHandler.getModItem("SGCraft", "stargateRing", 1, 0);
         final ItemStack chevronBlock = GTModHandler.getModItem("SGCraft", "stargateRing", 1, 1);
-        final ItemStack irisUpgrade = GTModHandler.getModItem("SGCraft", "sgIrisUpgrade" , 1, 0);
+        final ItemStack irisUpgrade = GTModHandler.getModItem("SGCraft", "sgIrisUpgrade", 1, 0);
 
         // region Proof Of Heroes
         GTValues.RA.stdBuilder()
@@ -833,7 +831,7 @@ public class MiracleTopRecipePool implements IRecipePool {
             .noOptimize()
             .specialValue(13500)
             .eut(RECIPE_MAX)
-            .duration(20 *99_999_999)
+            .duration(20 * 99_999_999)
             .addTo(MT);
 
         // StabiliseVoidMatter
@@ -841,21 +839,21 @@ public class MiracleTopRecipePool implements IRecipePool {
             .builder()
             .itemInputs(
                 setStackSize(Materials.CosmicNeutronium.getDust(1), 10_000_000),
-                setStackSize(Materials.Bedrockium.getDust(1),10_000_000),
-                setStackSize(Materials.Carbon.getDust(1),10_000_000),
-                setStackSize(Materials.Oilsands.getDust(1),10_000_000),
-                setStackSize(Materials.NiobiumTitanium.getDust(1),10_000_000),
-                setStackSize(MaterialsElements.STANDALONE.BLACK_METAL.getDust(1),10_000_000),
-                setStackSize(Materials.Naquadria.getDust(1),10_000_000),
-                setStackSize(Materials.Obsidian.getDust(1),10_000_000),
-                setStackSize(Materials.Coal.getDust(1),10_000_000),
-                setStackSize(Materials.NaquadahAlloy.getDust(1),10_000_000),
-                setStackSize(Materials.Tungsten.getDust(1),10_000_000),
-                setStackSize(MaterialsUEVplus.TranscendentMetal.getDust(1),10_000_000),
-                setStackSize(Materials.Perlite.getDust(1),10_000_000),
-                setStackSize(Materials.DarkAsh.getDust(1),10_000_000),
-                setStackSize(Materials.GraniticMineralSand.getDust(1),10_000_000),
-                setStackSize(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getDust(1),10_000_000)
+                setStackSize(Materials.Bedrockium.getDust(1), 10_000_000),
+                setStackSize(Materials.Carbon.getDust(1), 10_000_000),
+                setStackSize(Materials.Oilsands.getDust(1), 10_000_000),
+                setStackSize(Materials.NiobiumTitanium.getDust(1), 10_000_000),
+                setStackSize(MaterialsElements.STANDALONE.BLACK_METAL.getDust(1), 10_000_000),
+                setStackSize(Materials.Naquadria.getDust(1), 10_000_000),
+                setStackSize(Materials.Obsidian.getDust(1), 10_000_000),
+                setStackSize(Materials.Coal.getDust(1), 10_000_000),
+                setStackSize(Materials.NaquadahAlloy.getDust(1), 10_000_000),
+                setStackSize(Materials.Tungsten.getDust(1), 10_000_000),
+                setStackSize(MaterialsUEVplus.TranscendentMetal.getDust(1), 10_000_000),
+                setStackSize(Materials.Perlite.getDust(1), 10_000_000),
+                setStackSize(Materials.DarkAsh.getDust(1), 10_000_000),
+                setStackSize(Materials.GraniticMineralSand.getDust(1), 10_000_000),
+                setStackSize(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getDust(1), 10_000_000)
             )
             .fluidInputs(
                 Materials.Polycaprolactam.getMolten(10_000_000),
@@ -918,7 +916,7 @@ public class MiracleTopRecipePool implements IRecipePool {
         }
     }
 
-    public void loadMaxRecipe() {
+    public static void loadMaxRecipe() {
         ItemStack[] inStack = new ItemStack[]{
             ItemList.Circuit_Parts_ResistorXSMD.get(16),
             ItemList.Circuit_Parts_DiodeXSMD.get(16),
@@ -956,22 +954,22 @@ public class MiracleTopRecipePool implements IRecipePool {
 
     }
 
-    public void loadFlaskRecipe() {
+    public static void loadFlaskRecipe() {
         final int ITEMS_FLASK_COUNT = 100_000;
         // TODO -- Temporarily, be revised in the next version
         // LV FLASK
         GTValues.RA.stdBuilder()
             .itemInputs(
-                setStackSize(ItemList.Electric_Motor_LV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_LV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_LV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_LV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_LV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_LV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_LV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_LV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_LV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Microprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.RedstoneAlloy, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_LV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_LV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_LV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Microprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.RedstoneAlloy, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Iron.getPlasma(1_000_000_000)
@@ -986,16 +984,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.LvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_MV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_MV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_MV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_MV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_MV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_MV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_MV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_MV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_MV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Processor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorMV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_MV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_MV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_MV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Processor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorMV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Copper.getPlasma(1_000_000_000)
@@ -1010,16 +1008,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.MvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_HV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_HV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_HV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_HV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_HV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_HV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_HV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_HV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_HV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Nanoprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorHV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_HV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_HV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_HV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Nanoprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorHV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Nickel.getPlasma(1_000_000_000)
@@ -1034,16 +1032,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.HvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_EV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_EV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_EV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_EV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_EV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_EV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_EV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_EV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_EV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Quantumprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorEV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_EV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_EV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_EV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Quantumprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorEV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Titanium.getPlasma(1_000_000_000)
@@ -1058,16 +1056,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.EvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_IV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_IV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_IV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_IV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_IV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_IV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_IV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_IV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_IV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Crystalprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorIV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_IV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_IV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_IV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Crystalprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorIV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Tungsten.getPlasma(1_000_000_000)
@@ -1082,16 +1080,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.IvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_LuV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_LuV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_LuV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_LuV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_LuV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_LuV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_LuV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_LuV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_LuV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Neuroprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_LuV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_LuV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_LuV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Neuroprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Osmium.getPlasma(1_000_000_000)
@@ -1106,16 +1104,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.LuvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_ZPM.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_ZPM.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_ZPM.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_ZPM.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_ZPM.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_ZPM.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_ZPM.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_ZPM.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_ZPM.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_Bioprocessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorZPM, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_ZPM.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_ZPM.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_ZPM.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_Bioprocessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorZPM, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Naquadah.getPlasma(1_000_000_000)
@@ -1130,16 +1128,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.ZpmFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_OpticalProcessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_OpticalProcessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Neutronium.getPlasma(1_000_000_000)
@@ -1154,16 +1152,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.UvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UHV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UHV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UHV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UHV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UHV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UHV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UHV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UHV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UHV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_OpticalAssembly.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUHV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UHV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UHV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UHV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_OpticalAssembly.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUHV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Samarium.getPlasma(1_000_000_000)
@@ -1178,16 +1176,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.UhvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UEV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UEV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UEV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UEV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UEV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UEV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UEV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UEV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UEV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_CosmicProcessor.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUEV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UEV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UEV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UEV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_CosmicProcessor.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUEV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Americium.getPlasma(1_000_000_000)
@@ -1202,16 +1200,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.UevFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UIV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UIV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UIV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UIV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UIV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UIV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UIV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UIV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UIV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_CosmicAssembly.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUIV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UIV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UIV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UIV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_CosmicAssembly.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUIV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Thorium.getPlasma(1_000_000_000)
@@ -1226,16 +1224,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.UivFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UMV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UMV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UMV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UMV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UMV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UMV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UMV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UMV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UMV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_CosmicComputer.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUMV, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UMV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UMV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UMV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_CosmicComputer.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorUMV, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Plutonium241.getPlasma(1_000_000_000)
@@ -1250,16 +1248,16 @@ public class MiracleTopRecipePool implements IRecipePool {
         GTValues.RA.stdBuilder()
             .itemInputs(
                 GTCMItemList.UmvFlask.get(1),
-                setStackSize(ItemList.Electric_Motor_UXV.get(1),ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Electric_Motor_UXV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Piston_UXV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Electric_Pump_UXV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Field_Generator_UXV.get(1), ITEMS_FLASK_COUNT),
                 setStackSize(ItemList.Conveyor_Module_UXV.get(1), ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Robot_Arm_UXV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Emitter_UXV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Sensor_UXV.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(ItemList.Circuit_CosmicMainframe.get(1),ITEMS_FLASK_COUNT),
-                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Infinity, 1),ITEMS_FLASK_COUNT)
+                setStackSize(ItemList.Robot_Arm_UXV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Emitter_UXV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Sensor_UXV.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(ItemList.Circuit_CosmicMainframe.get(1), ITEMS_FLASK_COUNT),
+                setStackSize(GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Infinity, 1), ITEMS_FLASK_COUNT)
             )
             .fluidInputs(
                 Materials.Radon.getPlasma(1_000_000_000)
@@ -1295,17 +1293,17 @@ public class MiracleTopRecipePool implements IRecipePool {
         Wrapped_Circuit_LV,
         Wrapped_Circuit_MV,
         Wrapped_Circuit_HV,
-        Wrapped_Circuit_EV ,
-        Wrapped_Circuit_IV ,
+        Wrapped_Circuit_EV,
+        Wrapped_Circuit_IV,
         Wrapped_Circuit_LuV,
-        Wrapped_Circuit_ZPM ,
-        Wrapped_Circuit_UV ,
-        Wrapped_Circuit_UHV ,
-        Wrapped_Circuit_UEV ,
-        Wrapped_Circuit_UIV ,
-        Wrapped_Circuit_UMV ,
-        Wrapped_Circuit_UXV ,
-        Wrapped_Circuit_MAX ,
+        Wrapped_Circuit_ZPM,
+        Wrapped_Circuit_UV,
+        Wrapped_Circuit_UHV,
+        Wrapped_Circuit_UEV,
+        Wrapped_Circuit_UIV,
+        Wrapped_Circuit_UMV,
+        Wrapped_Circuit_UXV,
+        Wrapped_Circuit_MAX,
 
         Wrapped_Circuit_Parts_Crystal_Chip_Elite,
         Wrapped_Circuit_Parts_Crystal_Chip_Master,
@@ -1373,9 +1371,11 @@ public class MiracleTopRecipePool implements IRecipePool {
         Wrapped_Circuit_Parts_Crystal_Chip_Wetware,
         Wrapped_Circuit_Parts_Chip_Bioware;
         private ItemStack itemStack;
-        public ItemStack get(int amount){
+
+        public ItemStack get(int amount) {
             return copyAmount(amount, this.itemStack);
         }
+
         public void set(ItemStack itemStack) {
             this.itemStack = itemStack;
         }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/NeutronActivatorWithEURecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/NeutronActivatorWithEURecipePool.java
@@ -3,14 +3,11 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.expanded;
 import static com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe.NeutronActivatorRecipesWithEU;
 import static goodgenerator.api.recipe.GoodGeneratorRecipeMaps.neutronActivatorRecipes;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.util.GTRecipe;
 
-public class NeutronActivatorWithEURecipePool implements IRecipePool {
+public class NeutronActivatorWithEURecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         for (GTRecipe recipeOrigin : neutronActivatorRecipes.getAllRecipes()) {
             GTRecipe recipeNew = recipeOrigin.copy();

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/PreciseHighEnergyPhotonicQuantumMasterRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/PreciseHighEnergyPhotonicQuantumMasterRecipePool.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -27,10 +26,9 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 
-public class PreciseHighEnergyPhotonicQuantumMasterRecipePool implements IRecipePool {
+public class PreciseHighEnergyPhotonicQuantumMasterRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         TwistSpaceTechnology.LOG.info("PreciseHighEnergyPhotonicQuantumMasterRecipePool loading recipes.");
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/RapidHeatExchangeRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/RapidHeatExchangeRecipePool.java
@@ -6,7 +6,6 @@ import static com.Nxer.TwistSpaceTechnology.util.TstUtils.copyAmount;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import goodgenerator.api.recipe.GoodGeneratorRecipeMaps;
@@ -14,10 +13,9 @@ import gregtech.api.enums.Materials;
 import gregtech.api.util.GTRecipe;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class RapidHeatExchangeRecipePool implements IRecipePool {
+public class RapidHeatExchangeRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         FluidStack DenseSupercriticalSteam = Materials.DenseSupercriticalSteam.getGas(1);
 
         for (GTRecipe aRecipe : GoodGeneratorRecipeMaps.extremeHeatExchangerFuels.getAllRecipes()) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StarKernelForgeRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StarKernelForgeRecipePool.java
@@ -5,7 +5,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import bartworks.system.material.WerkstoffLoader;
@@ -15,15 +14,14 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsElements;
 
-public class StarKernelForgeRecipePool implements IRecipePool {
+public class StarKernelForgeRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         loadGeneralRecipes();
         loadManualRecipes();
     }
 
-    private void addRecipe(ItemStack[] itemInputs, FluidStack[] fluidInputs, FluidStack[] fluidOutputs, int eut,
+    private static void addRecipe(ItemStack[] itemInputs, FluidStack[] fluidInputs, FluidStack[] fluidOutputs, int eut,
         int duration) {
         TST_RecipeBuilder.builder()
             .itemInputs(itemInputs)
@@ -35,19 +33,19 @@ public class StarKernelForgeRecipePool implements IRecipePool {
             .addTo(GTCMRecipe.BallLightningRecipes);
     }
 
-    private void addRecipe(FluidStack[] fluidInputs, FluidStack[] fluidOutputs, int eut, int duration) {
+    private static void addRecipe(FluidStack[] fluidInputs, FluidStack[] fluidOutputs, int eut, int duration) {
         addRecipe(null, fluidInputs, fluidOutputs, eut, duration);
     }
 
-    private void addRecipe(FluidStack fluidInputs, FluidStack fluidOutputs, int eut) {
+    private static void addRecipe(FluidStack fluidInputs, FluidStack fluidOutputs, int eut) {
         addRecipe(new FluidStack[] { fluidInputs }, new FluidStack[] { fluidOutputs }, eut, 50);
     }
 
-    private void addRecipe(ItemStack itemInputs, FluidStack fluidOutputs, int eut) {
+    private static void addRecipe(ItemStack itemInputs, FluidStack fluidOutputs, int eut) {
         addRecipe(new ItemStack[] { itemInputs }, null, new FluidStack[] { fluidOutputs }, eut, 50);
     }
 
-    private void loadGeneralRecipes() {
+    private static void loadGeneralRecipes() {
         for (GTRecipe plasmaFuel : RecipeMaps.plasmaFuels.getAllRecipes()) {
             FluidStack plasma = GTUtility.getFluidForFilledItem(plasmaFuel.mInputs[0], true);
             if (plasma == null) {
@@ -77,7 +75,7 @@ public class StarKernelForgeRecipePool implements IRecipePool {
         }
     }
 
-    public void loadManualRecipes() {
+    public static void loadManualRecipes() {
 
         // Neon
         addRecipe(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StellarForgeRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StellarForgeRecipePool.java
@@ -19,7 +19,6 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.rewrites.TST_ItemID;
 import com.google.common.collect.Sets;
 
@@ -37,7 +36,7 @@ import gregtech.api.util.GTRecipeBuilder;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 
-public class StellarForgeRecipePool implements IRecipePool {
+public class StellarForgeRecipePool {
 
     public static final HashSet<String> IngotHotOreDictNames = new HashSet<>();
     public static final HashSet<String> IngotOreDictNames = new HashSet<>();
@@ -83,7 +82,7 @@ public class StellarForgeRecipePool implements IRecipePool {
         return true;
     }
 
-    public void initData() {
+    public static void initData() {
 
         for (String name : OreDictionary.getOreNames()) {
             if (name.startsWith("ingotHot")) {
@@ -138,7 +137,7 @@ public class StellarForgeRecipePool implements IRecipePool {
         }
     }
 
-    public void prepareEBFRecipes() {
+    public static void prepareEBFRecipes() {
         Set<Fluid> protectionGas = Sets.newHashSet(
             Materials.Hydrogen.mGas,
             Materials.Oxygen.mGas,
@@ -271,7 +270,7 @@ public class StellarForgeRecipePool implements IRecipePool {
         }
     }
 
-    public void prepareABSRecipes() {
+    public static void prepareABSRecipes() {
 
         for (GTRecipe recipe : GTPPRecipeMaps.alloyBlastSmelterRecipes.getAllRecipes()) {
             int minOutputFluidAmount = 144;
@@ -401,7 +400,7 @@ public class StellarForgeRecipePool implements IRecipePool {
         return out;
     }
 
-    public void loadManualRecipes() {
+    public static void loadManualRecipes() {
 
         // Meteoric Iron
         addToMiracleDoorRecipes(
@@ -447,12 +446,11 @@ public class StellarForgeRecipePool implements IRecipePool {
         }
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         initData();
     }
 
-    public void loadOnServerStarted() {
+    public static void loadOnServerStarted() {
         prepareEBFRecipes();
         prepareABSRecipes();
         loadManualRecipes();

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StellarMaterialSiphonRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/StellarMaterialSiphonRecipePool.java
@@ -9,14 +9,13 @@ import java.util.Map;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.Loader;
 import galaxyspace.SolarSystem.SolarSystemPlanets;
 import gregtech.api.enums.Materials;
 
-public class StellarMaterialSiphonRecipePool implements IRecipePool {
+public class StellarMaterialSiphonRecipePool {
 
     public static final Map<String, Map<Integer, FluidStack>> RECIPES = new HashMap<>();
 
@@ -65,8 +64,7 @@ public class StellarMaterialSiphonRecipePool implements IRecipePool {
         RECIPES.put("blackHole", blackHoleRecipes);// should replace with world later
     }
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if (Config.activateMegaSpaceStation) {
             addPumpingRecipes();
         }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CentrifugeRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CentrifugeRecipePool.java
@@ -3,8 +3,6 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_EV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_LV;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IRecipeMap;
@@ -12,10 +10,9 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 
-public class CentrifugeRecipePool implements IRecipePool {
+public class CentrifugeRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         final IRecipeMap centrifuge = GTPPRecipeMaps.centrifugeNonCellRecipes;
         final IRecipeMap centrifugeSingleBlock = RecipeMaps.centrifugeRecipes;
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ChemicalReactorRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ChemicalReactorRecipePool.java
@@ -3,8 +3,6 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 import static gregtech.api.enums.TierEU.RECIPE_MV;
 import static gregtech.api.enums.TierEU.RECIPE_ZPM;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import bartworks.system.material.WerkstoffLoader;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
@@ -14,11 +12,9 @@ import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 
-public class ChemicalReactorRecipePool implements IRecipePool {
+public class ChemicalReactorRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final IRecipeMap LCR = RecipeMaps.multiblockChemicalReactorRecipes;
 
         // Lithium Chloride

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CircuitAssemblerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CircuitAssemblerRecipePool.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.TierEU.RECIPE_LuV;
 import static gregtech.api.enums.TierEU.RECIPE_UIV;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -18,11 +17,9 @@ import gtPlusPlus.core.material.MaterialMisc;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import tectech.thing.CustomItemList;
 
-public class CircuitAssemblerRecipePool implements IRecipePool {
+public class CircuitAssemblerRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final IRecipeMap CA = RecipeMaps.circuitAssemblerRecipes;
 
         // CA recipes will be multiplied during the initialization of bartworks,

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CompressorRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/CompressorRecipePool.java
@@ -1,18 +1,15 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import ic2.api.item.IC2Items;
 
-public class CompressorRecipePool implements IRecipePool {
+public class CompressorRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final IRecipeMap Compressor = RecipeMaps.compressorRecipes;
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/DTPFRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/DTPFRecipePool.java
@@ -8,7 +8,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.Nxer.TwistSpaceTechnology.common.api.ModItemHandler;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -21,10 +20,9 @@ import gregtech.common.items.CombType;
 import gregtech.loaders.misc.GTBees;
 import gtPlusPlus.core.material.MaterialsElements;
 
-public class DTPFRecipePool implements IRecipePool {
+public class DTPFRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if (!Config.Registry_DTPF_ExtraRecipe) return;
 
         final IRecipeMap DTPF = RecipeMaps.plasmaForgeRecipes;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/DistillationRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/DistillationRecipePool.java
@@ -4,17 +4,14 @@ import static gregtech.api.enums.TierEU.RECIPE_IV;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 
-public class DistillationRecipePool implements IRecipePool {
+public class DistillationRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final IRecipeMap DT = RecipeMaps.distillationTowerRecipes;
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ExtractorRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ExtractorRecipePool.java
@@ -4,7 +4,6 @@ import static gregtech.api.enums.TierEU.RECIPE_LV;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.material.MaterialPool;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.IRecipeMap;
@@ -12,11 +11,9 @@ import gregtech.api.recipe.RecipeMaps;
 import magicbees.item.types.CombType;
 import magicbees.main.Config;
 
-public class ExtractorRecipePool implements IRecipePool {
+public class ExtractorRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         final IRecipeMap Extractor = RecipeMaps.fluidExtractionRecipes;
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FluidHeaterRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FluidHeaterRecipePool.java
@@ -1,11 +1,8 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
+public class FluidHeaterRecipePool {
 
-public class FluidHeaterRecipePool implements IRecipePool {
-
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
     }
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FluidSolidifierRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FluidSolidifierRecipePool.java
@@ -9,8 +9,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -22,10 +20,9 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 
-public class FluidSolidifierRecipePool implements IRecipePool {
+public class FluidSolidifierRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         final IRecipeMap fs = RecipeMaps.fluidSolidifierRecipes;
         // Mold Singularity
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FusionReactorRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/FusionReactorRecipePool.java
@@ -5,16 +5,13 @@ import static gregtech.api.recipe.RecipeMaps.fusionRecipes;
 
 import net.minecraftforge.fluids.FluidStack;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gtPlusPlus.core.material.MaterialsElements;
 
-public class FusionReactorRecipePool implements IRecipePool {
+public class FusionReactorRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         // // debug Recipe
         // GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/MixerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/MixerRecipePool.java
@@ -3,8 +3,6 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_EV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_LuV;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
@@ -14,10 +12,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class MixerRecipePool implements IRecipePool {
+public class MixerRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         // region Ta4HfC5
         GTValues.RA.stdBuilder()
             .itemInputs(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/NanoForgeRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/NanoForgeRecipePool.java
@@ -1,7 +1,6 @@
 package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import gregtech.api.enums.ItemList;
@@ -9,10 +8,9 @@ import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 
-public class NanoForgeRecipePool implements IRecipePool {
+public class NanoForgeRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         TST_RecipeBuilder.builder()
             .itemInputs(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ParticleColliderRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/ParticleColliderRecipePool.java
@@ -2,18 +2,15 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UV;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IRecipeMap;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.material.Particle;
 
-public class ParticleColliderRecipePool implements IRecipePool {
+public class ParticleColliderRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         final IRecipeMap PCRP = GTPPRecipeMaps.cyclotronRecipes;
         GTValues.RA.stdBuilder()
             .itemInputs(Particle.getBaseParticle(Particle.PROTON), Particle.getBaseParticle(Particle.ELECTRON))

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/QFTRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/QFTRecipePool.java
@@ -3,8 +3,6 @@ package com.Nxer.TwistSpaceTechnology.recipe.machineRecipe.original;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UHV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_UV;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import bartworks.system.material.WerkstoffLoader;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -15,10 +13,9 @@ import gtPlusPlus.core.item.chemistry.GenericChem;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class QFTRecipePool implements IRecipePool {
+public class QFTRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         final IRecipeMap QFT = GTPPRecipeMaps.quantumForceTransformerRecipes;
 
         // Palladium

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/SpaceAssemblerRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/original/SpaceAssemblerRecipePool.java
@@ -6,7 +6,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 
 import goodgenerator.util.ItemRefer;
@@ -19,10 +18,9 @@ import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.item.ModItems;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 
-public class SpaceAssemblerRecipePool implements IRecipePool {
+public class SpaceAssemblerRecipePool {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
 
         final RecipeMap<?> SA = com.gtnewhorizons.gtnhintergalactic.recipe.IGRecipeMaps.spaceAssemblerRecipes;
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/processingLineRecipe/DragonBloodRecipe.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/processingLineRecipe/DragonBloodRecipe.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 import com.Nxer.TwistSpaceTechnology.util.TstUtils;
 
 import gregtech.api.enums.GTValues;
@@ -30,10 +29,9 @@ import gtPlusPlus.xmod.forestry.bees.handler.GTPPDropType;
 import gtPlusPlus.xmod.forestry.bees.handler.GTPPPropolisType;
 import gtPlusPlus.xmod.forestry.bees.registry.GTPP_Bees;
 
-public class DragonBloodRecipe implements IRecipePool {
+public class DragonBloodRecipe {
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         if (Config.Registry_DragonBlood_ExtraRecipe) {
             // Fluid Heater
             GTValues.RA.stdBuilder()

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/processingLineRecipe/LanthanidesRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/processingLineRecipe/LanthanidesRecipePool.java
@@ -3,19 +3,15 @@ package com.Nxer.TwistSpaceTechnology.recipe.processingLineRecipe;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_EV;
 import static com.Nxer.TwistSpaceTechnology.util.enums.TierEU.RECIPE_ZPM;
 
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IRecipeMap;
 import gtnhlanth.api.recipe.LanthanidesRecipeMaps;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
-public class LanthanidesRecipePool implements IRecipePool {
+public class LanthanidesRecipePool {
 
-    @Override
-    public void loadRecipes() {
-
+    public static void loadRecipes() {
         IRecipeMap digester = LanthanidesRecipeMaps.digesterRecipes;
 
         // GT Rare Earth to Lanthanides process

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_Bartworks_OreHandler.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_Bartworks_OreHandler.java
@@ -22,7 +22,7 @@ import gregtech.api.util.GTUtility;
 
 public class OP_Bartworks_OreHandler {
 
-    public void processBWOreRecipes() {
+    public static void processBWOreRecipes() {
         for (Werkstoff werkstoff : Werkstoff.werkstoffHashSet) {
             if (!werkstoff.hasItemType(ore)) continue;
             ArrayList<ItemStack> outputs = new ArrayList<>();

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_GTPP_OreHandler.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_GTPP_OreHandler.java
@@ -24,7 +24,7 @@ import gtPlusPlus.core.material.MaterialsOres;
 
 public class OP_GTPP_OreHandler {
 
-    public Set<Material> addSpecials(Set<Material> set) {
+    public static Set<Material> addSpecials(Set<Material> set) {
         set.add(RARE_EARTH_LOW);
         set.add(RARE_EARTH_MID);
         set.add(RARE_EARTH_HIGH);
@@ -32,7 +32,7 @@ public class OP_GTPP_OreHandler {
         return set;
     }
 
-    public Set<Material> getGTPPOreMaterials() {
+    public static Set<Material> getGTPPOreMaterials() {
         Set<Material> gtppOres = new HashSet<>(51);
         for (Field field : MaterialsOres.class.getFields()) {
             if (field.getType() != Material.class) continue;
@@ -49,7 +49,7 @@ public class OP_GTPP_OreHandler {
         return gtppOres;
     }
 
-    public void processGTPPOreRecipes() {
+    public static void processGTPPOreRecipes() {
         for (Material ore : addSpecials(getGTPPOreMaterials())) {
             TST_RecipeBuilder.builder()
                 .itemInputs(ore.getOre(1))

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_NormalProcessing.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_NormalProcessing.java
@@ -34,7 +34,7 @@ public class OP_NormalProcessing {
     /**
      * Ore stone types enum
      */
-    public final Set<OrePrefixes> basicStoneTypes = Sets.newHashSet(
+    public static final Set<OrePrefixes> basicStoneTypes = Sets.newHashSet(
         OrePrefixes.ore,
         OrePrefixes.oreBasalt,
         OrePrefixes.oreBlackgranite,
@@ -43,7 +43,7 @@ public class OP_NormalProcessing {
         OrePrefixes.oreNetherrack,
         OrePrefixes.oreEndstone);
 
-    public final Set<OrePrefixes> basicStoneTypesExceptNormalStone = Sets.newHashSet(
+    public static final Set<OrePrefixes> basicStoneTypesExceptNormalStone = Sets.newHashSet(
         OrePrefixes.oreBasalt,
         OrePrefixes.oreBlackgranite,
         OrePrefixes.oreRedgranite,
@@ -51,9 +51,9 @@ public class OP_NormalProcessing {
         OrePrefixes.oreNetherrack,
         OrePrefixes.oreEndstone);
 
-    public final Map<Materials, ItemStack> processingLineMaterials = new HashMap<>();
+    public static final Map<Materials, ItemStack> processingLineMaterials = new HashMap<>();
 
-    public void initProcessingLineMaterials() {
+    public static void initProcessingLineMaterials() {
         processingLineMaterials.put(Materials.Platinum, WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 1));
         processingLineMaterials.put(Materials.Palladium, WerkstoffLoader.PDMetallicPowder.get(OrePrefixes.dust, 1));
         processingLineMaterials.put(Materials.Iridium, WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 1));
@@ -69,7 +69,7 @@ public class OP_NormalProcessing {
     // 535, 540, 541, 542, 543, 544, 545, 770, 810, 817, 826, 884, 894, 918, 920
     // );
 
-    public ItemStack getDustStack(Materials material, int amount) {
+    public static ItemStack getDustStack(Materials material, int amount) {
         if (SpecialProcessingLineMaterialInstead) {
             ItemStack t = processingLineMaterials.get(material);
             if (t != null) {
@@ -82,7 +82,7 @@ public class OP_NormalProcessing {
     /**
      * Generate recipes.
      */
-    public void enumOreProcessingRecipes() {
+    public static void enumOreProcessingRecipes() {
         initProcessingLineMaterials();
         Set<Materials> specialProcesses = Sets.newHashSet(
             Materials.Samarium,
@@ -106,8 +106,8 @@ public class OP_NormalProcessing {
             processOreRecipe(material, i);
         }
 
-        new OP_GTPP_OreHandler().processGTPPOreRecipes();
-        new OP_Bartworks_OreHandler().processBWOreRecipes();
+        OP_GTPP_OreHandler.processGTPPOreRecipes();
+        OP_Bartworks_OreHandler.processBWOreRecipes();
 
         processSpecialOreRecipe();
     }
@@ -115,7 +115,7 @@ public class OP_NormalProcessing {
     /**
      * Generate special ores recipes
      */
-    public void processSpecialOreRecipe() {
+    public static void processSpecialOreRecipe() {
         // spotless:off
 
         // Cerium ore
@@ -247,7 +247,7 @@ public class OP_NormalProcessing {
      * @param material The ore's Material.
      * @param ID       The material ID.
      */
-    public void processOreRecipe(Materials material, int ID) {
+    public static void processOreRecipe(Materials material, int ID) {
         if (GTOreDictUnificator.get(OrePrefixes.ore, material, 1) == null) return;
         ItemStack[] outputs = getOutputs(material, false);
         ItemStack[] outputsRich = getOutputs(material, true);
@@ -277,11 +277,11 @@ public class OP_NormalProcessing {
      * @param material      Input ore's material in GT design.
      * @param isRich        Is this ore a rich type.
      */
-    public void processOreRecipe(ItemStack inputOreItems, Materials material, boolean isRich) {
+    public static void processOreRecipe(ItemStack inputOreItems, Materials material, boolean isRich) {
         registryOreProcessRecipe(inputOreItems, getOutputs(material, isRich));
     }
 
-    public ItemStack[] getOutputs(Materials material, boolean isRich) {
+    public static ItemStack[] getOutputs(Materials material, boolean isRich) {
         List<ItemStack> outputs = new ArrayList<>();
 
         // check byproduct
@@ -330,7 +330,7 @@ public class OP_NormalProcessing {
         return outputs.toArray(new ItemStack[0]);
     }
 
-    public void registryOreProcessRecipe(ItemStack input, ItemStack[] output) {
+    public static void registryOreProcessRecipe(ItemStack input, ItemStack[] output) {
         if (input == null) return;
         TST_RecipeBuilder.builder()
             .itemInputs(input)
@@ -348,7 +348,7 @@ public class OP_NormalProcessing {
      * @param prefixes The style to check.
      * @return True is rich ore.
      */
-    public boolean isRich(OrePrefixes prefixes) {
+    public static boolean isRich(OrePrefixes prefixes) {
         return prefixes == OrePrefixes.oreNetherrack || prefixes == OrePrefixes.oreEndstone;
     }
 

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/Thaumcraft/TCRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/Thaumcraft/TCRecipePool.java
@@ -20,7 +20,6 @@ import net.minecraft.item.ItemStack;
 import com.Nxer.TwistSpaceTechnology.common.GTCMItemList;
 import com.Nxer.TwistSpaceTechnology.common.init.TstBlocks;
 import com.Nxer.TwistSpaceTechnology.config.Config;
-import com.Nxer.TwistSpaceTechnology.recipe.IRecipePool;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -39,7 +38,7 @@ import thaumcraft.common.config.ConfigItems;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.item.ModItems;
 
-public class TCRecipePool implements IRecipePool {
+public class TCRecipePool {
 
     public static InfusionRecipe infusionRecipeElvenWorkshop;
     public static InfusionRecipe infusionRecipeIndustrialMagicMatrix;
@@ -53,8 +52,7 @@ public class TCRecipePool implements IRecipePool {
 
     public static CrucibleRecipe crucibleRecipeArcaneHole;
 
-    @Override
-    public void loadRecipes() {
+    public static void loadRecipes() {
         /* Elven Workshop */
         infusionRecipeElvenWorkshop = ThaumcraftApi.addInfusionCraftingRecipe(
             "BH_ELVEN_WORKSHOP",

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/Thaumcraft/TCResearches.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/Thaumcraft/TCResearches.java
@@ -30,14 +30,14 @@ import thaumcraft.api.research.ResearchPage;
 
 public class TCResearches {
 
-    String TST_Path = "gtnhcommunitymod";
+    private static final String TST_Path = "gtnhcommunitymod";
 
-    public void register() {
+    public static void register() {
         loadResearchTab();
         loadResearches();
     }
 
-    public void loadResearchTab() {
+    public static void loadResearchTab() {
         ResearchCategories.registerCategory(
             "TST",
             new ResourceLocation(TST_Path, "textures/items/MetaItem01/33.png"),
@@ -47,7 +47,7 @@ public class TCResearches {
         // #zh_CN 扭曲空间科技
     }
 
-    public void loadResearches() {
+    public static void loadResearches() {
         new ResearchItem(
             "TST_WELCOME",
             // #tr tc.research_name.TST_WELCOME


### PR DESCRIPTION
Removed `IRecipeLoader`, and make all loaders _static_.

The instantiation of these loader classes are useless in most cases, since they are invoked only once.
