### PR TITLE
Fix #915

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_MagneticDrivePressureFormer.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_MagneticDrivePressureFormer.java
@@ -80,7 +80,7 @@ public class GT_TileEntity_MagneticDrivePressureFormer
      */
 
     public byte glassTier;
-    public HeatingCoilLevel coilLevel;
+    public HeatingCoilLevel coilLevel = HeatingCoilLevel.None;
 
     public HeatingCoilLevel getCoilLevel() {
         return coilLevel;


### PR DESCRIPTION
为磁驱压力成型机的线圈等级字段添加默认值

虽然这样做似乎并不是解决这个问题的正确做法，感觉应该从初始化顺序的角度入手。但我没有开发mod的经验，不知道该怎么修改。但直接添加默认值确实能解决问题，代价是刚进入游戏时，工业信息显示屏上的耗时倍率不正确，手动刷新或者机器执行配方后才能显示正确的耗时倍率。

另外，这里是修复后的jar，如果有人需要可以在此下载。

[TwistSpaceTechnology-0.6.16-bugfix.jar.zip](https://github.com/user-attachments/files/19603105/TwistSpaceTechnology-0.6.16-bugfix.jar.zip)
