### PR TITLE
Eye of wood dimension config

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_EyeOfWood.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_EyeOfWood.java
@@ -80,6 +80,7 @@ public class TST_EyeOfWood extends GTCM_MultiMachineBase<TST_EyeOfWood> {
     private static final int STANDARD_WATER_AMOUNT = STANDARD_WATER_BUCKET * 1000;
     private static final int STANDARD_LAVA_BUCKET = ValueEnum.StandardLavaNeed_EyeOfWood;
     private static final int STANDARD_LAVA_AMOUNT = STANDARD_LAVA_BUCKET * 1000;
+    private static final int STANDARD_DIMENSION_ID = ValueEnum.StandardDimensionID_EyeOfWood;
     private static final double STANDARD_SUBSTRATE = Math
         .pow(2_000_000_000d, 1d / Math.max(STANDARD_WATER_BUCKET, STANDARD_LAVA_BUCKET));
     private int storedWater = 0;
@@ -293,7 +294,7 @@ public class TST_EyeOfWood extends GTCM_MultiMachineBase<TST_EyeOfWood> {
             World world = aBaseMetaTileEntity.getWorld();
             int dimID = world.provider.dimensionId;
 
-            if (dimID != 0) {
+            if (dimID != STANDARD_DIMENSION_ID) {
                 explodeMultiblock();
                 return;
             }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/ValueEnum.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/ValueEnum.java
@@ -260,6 +260,7 @@ public final class ValueEnum {
     public static final int StandardWaterNeed_EyeOfWood = Config.StandardWaterNeed_EyeOfWood;
     public static final int StandardLavaNeed_EyeOfWood = Config.StandardLavaNeed_EyeOfWood;
     public static final int TicksPerProcessing_EyeOfWood = 20 * Config.SecondsPerProcessing_EyeOfWood;
+    public static final int StandardDimensionID_EyeOfWood = Config.StandardDimensionID_EyeOfWood;
     // endregion
 
     // region Space Apiary

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/config/Config.java
@@ -351,6 +351,7 @@ public class Config {
     public static int StandardWaterNeed_EyeOfWood = 256;
     public static int StandardLavaNeed_EyeOfWood = 256;
     public static int SecondsPerProcessing_EyeOfWood = 60;
+    public static int StandardDimensionID_EyeOfWood = 0;
 
     // endregion
 
@@ -567,6 +568,7 @@ public class Config {
         StandardWaterNeed_EyeOfWood = configuration.getInt("StandardWaterNeed_EyeOfWood", EOW, StandardWaterNeed_EyeOfWood, 1, 1024, "Standard amount (in L) of Water per processing need of Eye of Wood. Type: int");
         StandardLavaNeed_EyeOfWood = configuration.getInt("StandardLavaNeed_EyeOfWood", EOW, StandardLavaNeed_EyeOfWood, 1, 1024, "Standard amount (in L) of Lava per processing need of Eye of Wood. Type: int");
         SecondsPerProcessing_EyeOfWood = configuration.getInt("SecondsPerProcessing_EyeOfWood", EOW, SecondsPerProcessing_EyeOfWood, 1, 3600, "How many seconds per processing cost of Eye of Wood. Type: int");
+        StandardDimensionID_EyeOfWood = configuration.getInt("StandardDimensionID_EyeOfWood", EOW, StandardDimensionID_EyeOfWood, -9999, 9999, "Standard dimension the Eye of Wood is allowed in. Default 0 - Overworld. Type: int");
 
         // endregion
 


### PR DESCRIPTION
Adds customizable dimension for the eye of wood. ( limited to 1 dimension still so not any dimension )
This would be quite nice for unique runs that start in different dimensions than overworld.

For balance of the mod this would obviously be quite broken but once void miners unlock this is just a fancy void miner so its only really from EV - LUV this matters ( EV because you can't really automate EOW before EV anyway )