### PR TITLE
Fix recipe heat check not using the same behavior as ebf/mebf

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SwelegfyrBlastFurnace.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SwelegfyrBlastFurnace.java
@@ -397,7 +397,7 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
     }
 
     public int getCoilHeat() {
-        return (int) getCoilLevel().getHeat();
+        return (int) getCoilLevel().getHeat() + 100 * (GTUtility.getTier(getMaxInputVoltage()) - 2);
     }
 
     public void setCoilLevel(HeatingCoilLevel coilLevel) {
@@ -944,6 +944,7 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
         aNBT.setByte("mTier", controllerTier);
         aNBT.setByte("mGlass", glassTier);
         aNBT.setByte("mMode", (byte) machineMode);
+        aNBT.setInteger("mRecipeHeatingCapacity", getCoilHeat());
         aNBT.setInteger("mHeatingCapacity", mHeatingCapacity);
         aNBT.setBoolean("isBlazeFinishSet", isBlazeFinishSet);
         aNBT.setBoolean("isBlazeFinishClear", isBlazeFinishClear);
@@ -982,6 +983,7 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         final IGregTechTileEntity tileEntity = getBaseMetaTileEntity();
         if (tileEntity != null) {
+            tag.setInteger("mRecipeHeatingCapacity", getCoilHeat());
             tag.setInteger("mHeatingCapacity", mHeatingCapacity);
             tag.setInteger("maxHeatingCapacity", maxHeatingCapacity);
             tag.setInteger("correctBlazeCost", correctBlazeCost);
@@ -1014,6 +1016,14 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
         }
 
         currentTip.add(
+            // #tr Waila.SBF.0
+            // # Recipe Heat
+            // #zh_CN 当前炉温
+            (EnumChatFormatting.YELLOW + TextEnums.tr("Waila.SBF.0")
+                + textColon
+                + EnumChatFormatting.WHITE
+                + tag.getInteger("mRecipeHeatingCapacity")) + Kelvin);
+        currentTip.add(
             // #tr Waila.SBF.1
             // # Current Heat
             // #zh_CN 当前炉温
@@ -1043,9 +1053,11 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
     @Override
     public String[] getInfoData() {
         String[] origin = super.getInfoData();
-        String[] ret = new String[origin.length + 1];
+        String[] ret = new String[origin.length + 2];
         System.arraycopy(origin, 0, ret, 0, origin.length);
         ret[origin.length] = EnumChatFormatting.AQUA + TextEnums
+            .tr("Waila.SBF.0") + textColon + EnumChatFormatting.GOLD + getCoilHeat() + Kelvin;
+        ret[origin.length + 1] = EnumChatFormatting.AQUA + TextEnums
             .tr("Waila.SBF.1") + textColon + EnumChatFormatting.GOLD + mHeatingCapacity + Kelvin;
         return ret;
     }

--- a/src/main/resources/assets/gtnhcommunitymod/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhcommunitymod/lang/en_US.lang
@@ -2147,3 +2147,4 @@ item.MetaItemFlask.10.name=UIV FLASK
 item.MetaItemFlask.11.name=UMV FLASK
 item.MetaItemFlask.12.name=UXV FLASK
 item.MetaItemAdderFlask.name=Test Item
+Waila.SBF.0=Recipe Heat

--- a/src/main/resources/assets/gtnhcommunitymod/lang/zh_CN.lang
+++ b/src/main/resources/assets/gtnhcommunitymod/lang/zh_CN.lang
@@ -2147,3 +2147,4 @@ item.MetaItemFlask.10.name=UIV FLASK
 item.MetaItemFlask.11.name=UMV FLASK
 item.MetaItemFlask.12.name=UXV FLASK
 item.MetaItemAdderFlask.name=测试物品
+Waila.SBF.0=当前炉温


### PR DESCRIPTION
As the title suggests the Swelegfyr Blast Furnace isn't adding the coil heat increase from the energy input tier.
This makes you for example unable to make UEV superconductor in the Swelegfyr Blast furnace when you have Infinity coils + 1 UXV amp  of power. While this is possible in the Mega EBF.

This change does end up buffing the max heat in passive mode since the base heat gets increased.

( The Chinese localized text is probably wrong - copy pasted from the 01 line )

Issue:
![Issue](https://github.com/user-attachments/assets/f8951e4c-3be1-4a43-b14e-a0a7eb1de5f4)

Before:
![Before](https://github.com/user-attachments/assets/b3eba700-75af-4d8e-8011-2e4b7ecf8dcc)

After:
![After](https://github.com/user-attachments/assets/591965c8-ca6f-4185-bd03-1c58d845760f)
