### PR TITLE
Dependency Version Automation

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+build/
+.gradle/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.google.code.gson:gson:2.13.1")
+}

--- a/buildSrc/src/main/groovy/TwistVersions.groovy
+++ b/buildSrc/src/main/groovy/TwistVersions.groovy
@@ -1,0 +1,72 @@
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import twist_gradle.ManifestLoader
+import twist_gradle.entity.Manifest
+import twist_gradle.util.TwistFileUtils
+
+class TwistVersions {
+
+    private static final Logger LOG = LoggerFactory.getLogger("TwistVersions")
+
+    private static Manifest man
+    private static Map<String, String> versionLookup
+
+    static {
+        // get the manifest from either cache or fetch online.
+        man = loadOrFetchManifest(new File("build"), "2.7.4")
+
+        // mapping the mods to versions
+        versionLookup = new HashMap<>()
+        man.github_mods.each { key, value ->
+            versionLookup[key] = value.version
+        }
+        man.external_mods.each { key, value ->
+            versionLookup[key] = value.version
+        }
+    }
+
+    /**
+     * A magic function provided by groovy where you can use {@code TwistVersions["SOME_STRING"]} to invoke this.
+     *
+     * @param propertyName
+     * @return
+     */
+    static String getAt(String propertyName) {
+        return versionLookup[propertyName]
+    }
+
+    private static Manifest loadOrFetchManifest(File cacheDir, String manifestVersion, boolean forceFetch = false) {
+        var cachedFile = new File(cacheDir, "gtnhManifest-${manifestVersion}.json")
+
+        // for 3 special versions, we enable force fetch automatically.
+        if(manifestVersion in ["daily", "experimental", "nightly"]) {
+            forceFetch = true
+        }
+
+        if (!forceFetch && cachedFile.exists()) {
+            try {
+                return ManifestLoader.loadManifest(cachedFile.newReader())
+            } catch (Exception e) {
+                LOG.warn("Cached manifest at {} was corrupted and unable to be loaded.", cachedFile, e)
+                cachedFile.delete()
+            }
+        }
+
+        Manifest manifest
+        try {
+            manifest = ManifestLoader.fetchManifest(manifestVersion)
+        } catch (Exception e) {
+            LOG.error("Failed to fetch the manifest (version = {})", manifestVersion, e)
+            throw new RuntimeException(e)
+        }
+
+        try {
+            TwistFileUtils.ensureFile(cachedFile, true, true)
+            cachedFile.write(ManifestLoader.saveManifest(manifest))
+        } catch (Exception e) {
+            LOG.warn("Failed to cache the manifest at {}", cachedFile, e)
+        }
+
+        return manifest
+    }
+}

--- a/buildSrc/src/main/groovy/twist_gradle/ManifestLoader.groovy
+++ b/buildSrc/src/main/groovy/twist_gradle/ManifestLoader.groovy
@@ -1,0 +1,25 @@
+package twist_gradle
+
+import com.google.gson.Gson
+import twist_gradle.entity.Manifest
+
+class ManifestLoader {
+
+    private static final Gson GSON = new Gson()
+    private static final String MANIFEST_URL = "https://raw.githubusercontent.com/GTNewHorizons/DreamAssemblerXXL/refs/heads/master/releases/manifests/%s.json"
+
+    static Manifest fetchManifest(String version) {
+        var urlString = MANIFEST_URL.formatted(version)
+        var url = new URI(urlString).toURL()
+        return GSON.fromJson(url.newReader(), Manifest.class)
+    }
+
+    static Manifest loadManifest(Reader strReader) {
+        return GSON.fromJson(strReader, Manifest.class)
+    }
+
+    static String saveManifest(Manifest manifest) {
+        return GSON.toJson(manifest, Manifest.class)
+    }
+
+}

--- a/buildSrc/src/main/groovy/twist_gradle/entity/Manifest.groovy
+++ b/buildSrc/src/main/groovy/twist_gradle/entity/Manifest.groovy
@@ -1,0 +1,13 @@
+package twist_gradle.entity
+
+import groovy.transform.ToString
+
+@ToString
+class Manifest {
+    String version
+    String last_version // previous version
+    String last_updated
+    String config
+    Map<String, Mod> github_mods
+    Map<String, Mod> external_mods
+}

--- a/buildSrc/src/main/groovy/twist_gradle/entity/Mod.groovy
+++ b/buildSrc/src/main/groovy/twist_gradle/entity/Mod.groovy
@@ -1,0 +1,9 @@
+package twist_gradle.entity
+
+import groovy.transform.ToString
+
+@ToString
+class Mod {
+    String version
+    String side
+}

--- a/buildSrc/src/main/groovy/twist_gradle/util/TwistFileUtils.groovy
+++ b/buildSrc/src/main/groovy/twist_gradle/util/TwistFileUtils.groovy
@@ -1,0 +1,63 @@
+package twist_gradle.util
+
+
+import org.gradle.api.file.FileSystemLocation
+
+import java.nio.file.Path
+
+class TwistFileUtils {
+
+    static void ensureDirectory(Object filelike, boolean allowDelete = false) {
+        var file = filelikeToFile(filelike)
+        if(!file.isDirectory()) {
+            if(allowDelete) {
+                file.delete()
+            } else {
+                throw new IllegalStateException("File ${file} exists but it wasn't a directory.")
+            }
+        }
+        if(!file.exists()) {
+            file.mkdirs()
+        }
+    }
+
+    static void ensureFile(Object filelike, boolean allowDelete = false, boolean allowCreateParent = true) {
+        var file = filelikeToFile(filelike)
+        var parent = file.parentFile
+
+        if(!parent.exists()) {
+            if(allowCreateParent) {
+                ensureDirectory(parent, allowDelete)
+            } else {
+                throw new IllegalStateException("Parent file ${parent} of file ${file} doesn't exists.")
+            }
+        }
+
+        if(!file.isFile()) {
+            if(allowDelete) {
+                file.delete()
+            } else {
+                throw new IllegalStateException("File ${file} exists but it wasn't a directory.")
+            }
+        }
+
+        if(!file.exists()) {
+            file.createNewFile()
+        }
+    }
+
+    static File filelikeToFile(Object filelike) {
+        if (filelike instanceof File) {
+            return filelike
+        } else if (filelike instanceof Path) {
+            return filelike.toFile()
+        } else if (filelike instanceof String) {
+            return new File(filelike)
+        } else if (filelike instanceof FileSystemLocation) { // gradle support
+            return filelike.getAsFile()
+        } else {
+            throw new IllegalStateException("Type ${filelike.class.canonicalName} is not supported.")
+        }
+    }
+
+}

--- a/buildSrc/src/test/groovy/TestMainManifestLoader.groovy
+++ b/buildSrc/src/test/groovy/TestMainManifestLoader.groovy
@@ -1,0 +1,15 @@
+import twist_gradle.ManifestLoader
+
+class TestMainManifestLoader {
+
+    static void main(String[] args) {
+        try {
+            ManifestLoader.fetchManifest("2.7.4").tap { println it }
+            ManifestLoader.fetchManifest("daily").tap { println it }
+        } catch (Exception e) {
+            e.printStackTrace()
+            println "Failed to run the tests."
+        }
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,35 +34,53 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.118:dev')
-    implementation('com.github.GTNewHorizons:GTNHLib:0.6.0:dev')
-    implementation('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.3.54-gtnh:dev')
-    implementation('com.github.GTNewHorizons:GTNH-Intergalactic:1.4.34:dev')
-    implementation('com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.99:dev')
-    implementation('com.github.GTNewHorizons:Avaritia:1.59:dev')
-    implementation('com.github.GTNewHorizons:Avaritiaddons:1.8.4-GTNH:dev')
-    implementation('com.github.GTNewHorizons:Eternal-Singularity:1.2.1:dev')
-    implementation('com.github.GTNewHorizons:Universal-Singularities:8.9.0:dev')
-    implementation('com.github.GTNewHorizons:MagicBees:2.9.1-GTNH:dev')
-    implementation('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
-    implementation('com.github.GTNewHorizons:ThaumicEnergistics:1.6.27-GTNH:dev')
-    implementation('com.github.GTNewHorizons:Botania:1.11.7-GTNH:dev')
-    implementation('com.github.GTNewHorizons:supersolarpanels:1.1.3:dev')
+    implementation(gtnh("GT5-Unofficial"))
+    implementation(gtnh("GTNHLib"))
+    implementation(gtnh("AE2FluidCraft-Rework"))
+    implementation(gtnh("GTNH-Intergalactic"))
+    implementation(gtnh("NewHorizonsCoreMod"))
+    implementation(gtnh("Avaritia"))
+    implementation(gtnh("Avaritiaddons"))
+    implementation(gtnh("Eternal-Singularity"))
+    implementation(gtnh("Universal-Singularities"))
+    implementation(gtnh("MagicBees"))
+    implementation(gtnh("ThaumicEnergistics"))
+    implementation(gtnh("Botania"))
+    implementation(gtnh("supersolarpanels"))
+    implementation(gtnh("Electro-Magic-Tools"))
+    implementation(gtnh("Hodgepodge"))
+    implementation(gtnh("WitcheryExtras"))
+    implementation(gtnh("BloodMagic"))
+    implementation(gtnh("EnderIO"))
+    implementation(gtnh("EnderCore"))
+
+    runtimeOnlyNonPublishable(gtnh("BlockRenderer6343")) { transitive = false }
+
+    implementation("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     implementation(rfg.deobf('curse.maven:advsolar-362768:2885953'))
-    implementation('com.github.GTNewHorizons:Electro-Magic-Tools:1.5.17:dev')
-    implementation('com.github.GTNewHorizons:Hodgepodge:2.5.90:dev')
     //These 2 deps have conflicts with Amun-Ra by default, see Twist-Space-Technology-Mod#150
     compileOnly(rfg.deobf('curse.maven:witchery-69673:2234410'))
-    implementation('com.github.GTNewHorizons:WitcheryExtras:1.3.0:dev')
     implementation('com.google.auto.value:auto-value-annotations:1.10.1')
     annotationProcessor('com.google.auto.value:auto-value:1.10.1')
     //These 2 deps are for mixin
 
-    implementation('com.github.GTNewHorizons:BloodMagic:1.6.11:dev')
-    implementation('com.github.GTNewHorizons:EnderIO:2.8.24:dev')
-    implementation('com.github.GTNewHorizons:EnderCore:0.4.6:dev')
+}
 
-    // dependencies for mod testing
-    // using transitive to prevent mod duplication and conflicts
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.2.16:dev") { transitive = false }
+/**
+ * Generate a dependency notation for projects that:
+ * <ul>
+ *     <li>Group name is {@code com.github.GTNewHorizons}.
+ *     <li>Name in the Manifest is same to the artifact name.
+ *     <li>Version is retrievable in Manifest.
+ * </ul>
+ *
+ * You can visit <a href="https://github.com/GTNewHorizons/DreamAssemblerXXL/tree/master/releases/manifests">the manifests in GitHub</a>.
+ *
+ * @param name       the name of the dependency in the manifest.
+ * @param classifier the classifier
+ * @return the generated notation
+ */
+static String gtnh(String name, String classifier = "dev") {
+    // com.github.GTNewHorizons:{name}:{version of name}:{classifier}
+    return "com.github.GTNewHorizons:${name}:${TwistVersions[name]}:${classifier}"
 }


### PR DESCRIPTION
Added dependency version automation by release manifests.

It'll read the release manifest of desired version, and generate a map of version info, which can be retrieved in `dependencies.gradle`.

There are few restrictions for this approach:

- The dependency must be published in group `com.github.GTNewHorizons`
- The dependency must be with a same name in the manifest.
- The dependency must be present in the manifest.

And, you must have a _nice_ network to access `raw.githubusercontent.com`.