### PR TITLE
Updated TSTStructureUtility & Re-Fixed the beacon issue

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/api/ModBlocksHandler.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/api/ModBlocksHandler.java
@@ -68,6 +68,7 @@ public final class ModBlocksHandler {
     public static Pair<Block, Integer> BlockArcane_1;
     public static Pair<Block, Integer> BlockArcane_4;
     public static Pair<Block, Integer> HorizontalDirt;
+    public static Pair<Block, Integer> ChiselBeacon_1;
     // public static Pair<Block, Integer> BlockArcane_6;
 
     // endregion
@@ -167,11 +168,13 @@ public final class ModBlocksHandler {
             BlockArcane_4 = Pair.of(Block.getBlockFromName(Mods.Chisel.ID + ":arcane"), 4);
             HorizontalDirt = Pair.of(Block.getBlockFromName(Mods.Chisel.ID + ":dirt"), 9);
             // BlockArcane_6 = Pair.of(Block.getBlockFromName(Mods.Chisel.ID + ":arcane"), 6);
+            ChiselBeacon_1 = Pair.of(Block.getBlockFromName(Mods.Chisel.ID + ":beacon"), 1);
         } else {
             BlockArcane_1 = Pair.of(Blocks.quartz_block, 0);
             BlockArcane_4 = Pair.of(Blocks.quartz_block, 1);
             HorizontalDirt = Pair.of(Blocks.dirt, 0);
             // BlockArcane_6 = Pair.of(Blocks.quartz_block, 2);
+            ChiselBeacon_1 = Pair.of(Blocks.beacon, 0);
         }
 
         if (Mods.ExtraUtilities.isModLoaded()) {

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/GT_TileEntity_IndustrialMagicMatrix.java
@@ -5,7 +5,6 @@ import static com.Nxer.TwistSpaceTechnology.util.TextLocalization.StructureTooCo
 import static com.dreammaster.block.BlockList.BloodyThaumium;
 import static com.dreammaster.block.BlockList.BloodyVoid;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAnyMeta;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofTileAdder;
@@ -16,7 +15,6 @@ import static goodgenerator.loader.Loaders.magicCasing;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.OutputBus;
-import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE_ACTIVE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE_ACTIVE_GLOW;
@@ -37,7 +35,6 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
@@ -58,6 +55,7 @@ import com.Nxer.TwistSpaceTechnology.common.misc.OverclockType;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.IndustrialMagicMatrixRecipeIndexKey;
 import com.Nxer.TwistSpaceTechnology.system.Thaumcraft.TCRecipeTools;
+import com.Nxer.TwistSpaceTechnology.util.TSTStructureUtility;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.TextLocalization;
 import com.google.common.collect.ImmutableList;
@@ -2990,11 +2988,7 @@ public class GT_TileEntity_IndustrialMagicMatrix extends GTCM_MultiMachineBase<G
                 .addElement('5', ofBlock(blockStoneDevice, 11))
                 .addElement('6', ofChain(ofBlock(blockCosmeticSolid, 7), ofBlock(blockStoneDevice, 7)))
                 .addElement('7', ofBlock(blockStoneDevice, 1))
-                .addElement(
-                    '8',
-                    ofChain(
-                        EtFuturumRequiem.isModLoaded() ? ofBlockAnyMeta(Block.getBlockFromName("etfuturum:beacon"))
-                            : ofBlockAnyMeta(Blocks.beacon)))
+                .addElement('8', TSTStructureUtility.CommonElements.BlockBeacon.get())
                 .build();
         }
         return STRUCTURE_DEFINITION;

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_BloodyHell.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_BloodyHell.java
@@ -4,6 +4,7 @@ import static WayofTime.alchemicalWizardry.ModBlocks.blockLifeEssence;
 import static com.Nxer.TwistSpaceTechnology.common.api.ModBlocksHandler.BloodInfusedDiamondBlock;
 import static com.Nxer.TwistSpaceTechnology.common.api.ModBlocksHandler.BloodInfusedGlowstone;
 import static com.Nxer.TwistSpaceTechnology.common.api.ModBlocksHandler.BloodInfusedIronBlock;
+import static com.Nxer.TwistSpaceTechnology.common.api.ModBlocksHandler.ChiselBeacon_1;
 import static com.Nxer.TwistSpaceTechnology.common.init.TstBlocks.MetaBlockCasing02;
 import static com.Nxer.TwistSpaceTechnology.util.TextLocalization.BLUE_PRINT_INFO;
 import static com.Nxer.TwistSpaceTechnology.util.TextLocalization.ModName;
@@ -21,7 +22,6 @@ import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.Textures.BlockIcons.casingTexturePages;
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
-import static net.minecraft.block.Block.getBlockFromName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +55,7 @@ import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.BloodyHellAlchemi
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.metadata.BloodyHellTierKey;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.recipeResult.ResultInsufficientTier;
 import com.Nxer.TwistSpaceTechnology.util.BloodMagicHelper;
+import com.Nxer.TwistSpaceTechnology.util.TSTStructureUtility;
 import com.Nxer.TwistSpaceTechnology.util.TaskerenAdvancedMathUtils;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.TstUtils;
@@ -323,8 +324,8 @@ public class TST_BloodyHell extends GTCM_MultiMachineBase<TST_BloodyHell> implem
                 .addElement('L', ofBlock(BloodInfusedDiamondBlock.getLeft(), BloodInfusedDiamondBlock.getRight()))
                 .addElement(
                     'M',
-                    Mods.Chisel.isModLoaded() ? ofBlock(getBlockFromName("chisel:beacon"), 1)
-                        : ofBlockAnyMeta(Blocks.beacon))
+                    Mods.Chisel.isModLoaded() ? ofBlock(ChiselBeacon_1.getLeft(), ChiselBeacon_1.getRight())
+                        : TSTStructureUtility.CommonElements.BlockBeacon.get())
                 .addElement(
                     'N',
                     ofChain(

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_IndustrialAlchemyTower.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_IndustrialAlchemyTower.java
@@ -58,7 +58,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityBeacon;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -72,12 +71,14 @@ import com.Nxer.TwistSpaceTechnology.common.misc.OverclockType;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.common.tile.TileArcaneHole;
 import com.Nxer.TwistSpaceTechnology.system.Thaumcraft.TCRecipeTools;
+import com.Nxer.TwistSpaceTechnology.util.TSTStructureUtility;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.TextLocalization;
 import com.Nxer.TwistSpaceTechnology.util.TstUtils;
 import com.google.common.collect.ImmutableList;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
+import com.gtnewhorizon.structurelib.structure.StructureUtility;
 
 import emt.tile.TileElectricCloud;
 import gregtech.api.interfaces.ITexture;
@@ -415,7 +416,6 @@ public class TST_IndustrialAlchemyTower extends GTCM_MultiMachineBase<TST_Indust
                 .addElement('J', ofBlock(blockMetalDevice, 3))
                 .addElement('K', ofBlock(blockMetalDevice, 9))
                 .addElement('L', ofBlock(BlockTranslucent.getLeft(), BlockTranslucent.getRight()))
-                // .addElement('M', ofBlock(BlockBrickTranslucent.getLeft(), BlockBrickTranslucent.getRight()))
                 .addElement('M', ofBlock(BlockTranslucent.getLeft(), BlockTranslucent.getRight()))
                 .addElement('N', ofVariableBlock(channel, BlockArcane_1.getLeft(), BlockArcane_1.getRight(), list))
                 .addElement('O', ofVariableBlock(channel, BlockArcane_4.getLeft(), BlockArcane_4.getRight(), list))
@@ -431,9 +431,9 @@ public class TST_IndustrialAlchemyTower extends GTCM_MultiMachineBase<TST_Indust
                     'W',
                     ofChain(
                         ofTileAdder(TST_IndustrialAlchemyTower::addNodeEnergized, blockAiry, 0),
-                        ofBlock(Blocks.air, 0)))
+                        StructureUtility.isAir()))
                 .addElement('X', ofAccurateTile(TileElectricCloud.class, electricCloud, 0))
-                .addElement('Y', ofAccurateTile(TileEntityBeacon.class, Blocks.beacon, 0))
+                .addElement('Y', TSTStructureUtility.CommonElements.BlockBeacon.get())
                 .addElement('Z', ofAccurateTileExt(TileNitor.class, blockAiry, 1, ConfigItems.itemResource, 1))
                 .build();
         }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SkypiercerTower.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SkypiercerTower.java
@@ -48,6 +48,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.Nxer.TwistSpaceTechnology.util.TSTStructureUtility;
 import com.Nxer.TwistSpaceTechnology.util.TextEnums;
 import com.Nxer.TwistSpaceTechnology.util.TstUtils;
 import com.google.common.collect.ImmutableList;
@@ -245,7 +246,7 @@ public class TST_SkypiercerTower extends MTETooltipMultiBlockBaseEM implements I
                 .addElement(
                     'L',
                     ofChain(ofAccurateTileAdder(TST_SkypiercerTower::addTileElectricCloud, electricCloud, 0)))
-                .addElement('M', ofBlockAnyMeta(Blocks.beacon, 1))
+                .addElement('M', TSTStructureUtility.CommonElements.BlockBeacon.get())
                 .addElement('N', ofAccurateTileExt(TileNitor.class, blockAiry, 1, ConfigItems.itemResource, 1))
                 .addElement(
                     'N',


### PR DESCRIPTION
跟进上游结构库新增方法
同时呢对 #1058  进行改进( 
或者说没修完全 还有些许问题 不支持生存模式自动放置信标
默认信标是使用ETF的 但是玩家压根不能获取
这个PR则是完全修复了 同时对其他机器 像是血狱/工业炼金/穿云塔 也进行了跟进 

<img width="361" height="185" alt="image" src="https://github.com/user-attachments/assets/06aed469-e044-44b9-bb2c-4b580fff2fee" />

