### PR TITLE
修复 GT5 2.9.0beta 矿石处理厂矿辞不适配

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_NormalProcessing.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_NormalProcessing.java
@@ -7,49 +7,31 @@ import static com.Nxer.TwistSpaceTechnology.system.OreProcess.logic.OP_Values.Sp
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
 
-import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.recipeMap.GTCMRecipe;
 import com.Nxer.TwistSpaceTechnology.util.recipes.TST_RecipeBuilder;
 import com.google.common.collect.Sets;
 
 import bartworks.system.material.WerkstoffLoader;
 import goodgenerator.items.GGMaterial;
-import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.StoneType;
+import gregtech.api.objects.ItemData;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 import ic2.core.Ic2Items;
 
 public class OP_NormalProcessing {
-
-    /**
-     * Ore stone types enum
-     */
-    public static final Set<OrePrefixes> basicStoneTypes = Sets.newHashSet(
-        OrePrefixes.ore,
-        OrePrefixes.oreBasalt,
-        OrePrefixes.oreBlackgranite,
-        OrePrefixes.oreRedgranite,
-        OrePrefixes.oreMarble,
-        OrePrefixes.oreNetherrack,
-        OrePrefixes.oreEndstone);
-
-    public static final Set<OrePrefixes> basicStoneTypesExceptNormalStone = Sets.newHashSet(
-        OrePrefixes.oreBasalt,
-        OrePrefixes.oreBlackgranite,
-        OrePrefixes.oreRedgranite,
-        OrePrefixes.oreMarble,
-        OrePrefixes.oreNetherrack,
-        OrePrefixes.oreEndstone);
 
     public static final Map<Materials, ItemStack> processingLineMaterials = new HashMap<>();
 
@@ -91,20 +73,7 @@ public class OP_NormalProcessing {
             Materials.NaquadahEnriched,
             Materials.Naquadria);
 
-        // generate normal materials' ore processing recipes
-        for (int i = 0; i < GregTechAPI.sGeneratedMaterials.length; i++) {
-            if (GregTechAPI.sGeneratedMaterials[i] == null) continue;
-
-            Materials material = GregTechAPI.sGeneratedMaterials[i];
-
-            // rule out special materials
-            if (!specialProcesses.isEmpty() && specialProcesses.contains(material)) {
-                specialProcesses.remove(material);
-                continue;
-            }
-            // generate recipes
-            processOreRecipe(material, i);
-        }
+        processOreDictionaryRecipes(specialProcesses);
 
         OP_GTPP_OreHandler.processGTPPOreRecipes();
         OP_Bartworks_OreHandler.processBWOreRecipes();
@@ -124,15 +93,7 @@ public class OP_NormalProcessing {
                 WerkstoffMaterialPool.CeriumOreConcentrate.get(OrePrefixes.dust, 11) };
             ItemStack[] outputsRich = new ItemStack[] {
                 WerkstoffMaterialPool.CeriumOreConcentrate.get(OrePrefixes.dust, 22) };
-            // registry raw ore item style
-            registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Cerium, 1), outputs);
-            for (OrePrefixes prefixes : basicStoneTypes) {
-                if (GTOreDictUnificator.get(prefixes, Materials.Cerium, 1) == null) continue;
-                registryOreProcessRecipe(
-                    GTOreDictUnificator.get(prefixes, Materials.Cerium, 1),
-                    isRich(prefixes) ? outputsRich : outputs
-                );
-            }
+            registryOreDictionaryRecipes(Materials.Cerium, outputs, outputsRich);
         }
 
         // Samarium Ore
@@ -141,15 +102,7 @@ public class OP_NormalProcessing {
                 WerkstoffMaterialPool.SamariumOreConcentrate.get(OrePrefixes.dust, 11) };
             ItemStack[] outputsRich = new ItemStack[] {
                 WerkstoffMaterialPool.SamariumOreConcentrate.get(OrePrefixes.dust, 22) };
-            // registry raw ore item style
-            registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Samarium, 1), outputs);
-            for (OrePrefixes prefixes : basicStoneTypes) {
-                if (GTOreDictUnificator.get(prefixes, Materials.Samarium, 1) == null) continue;
-                registryOreProcessRecipe(
-                    GTOreDictUnificator.get(prefixes, Materials.Samarium, 1),
-                    isRich(prefixes) ? outputsRich : outputs
-                );
-            }
+            registryOreDictionaryRecipes(Materials.Samarium, outputs, outputsRich);
         }
 
         // Naquadah Ore
@@ -158,15 +111,7 @@ public class OP_NormalProcessing {
                 GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 3), };
             ItemStack[] outputsRich = new ItemStack[] { GGMaterial.naquadahEarth.get(OrePrefixes.dust, 16),
                 GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 8), };
-            // registry raw ore item style
-            registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Naquadah, 1), outputs);
-            for (OrePrefixes prefixes : basicStoneTypes) {
-                if (GTOreDictUnificator.get(prefixes, Materials.Naquadah, 1) == null) continue;
-                registryOreProcessRecipe(
-                    GTOreDictUnificator.get(prefixes, Materials.Naquadah, 1),
-                    isRich(prefixes) ? outputsRich : outputs
-                );
-            }
+            registryOreDictionaryRecipes(Materials.Naquadah, outputs, outputsRich);
         }
 
         // Enriched Naquadah Ore
@@ -175,15 +120,7 @@ public class OP_NormalProcessing {
                 GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 3) };
             ItemStack[] outputsRich = new ItemStack[] { GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 16),
                 GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 6) };
-            // registry raw ore item style
-            registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.NaquadahEnriched, 1), outputs);
-            for (OrePrefixes prefixes : basicStoneTypes) {
-                if (GTOreDictUnificator.get(prefixes, Materials.NaquadahEnriched, 1) == null) continue;
-                registryOreProcessRecipe(
-                    GTOreDictUnificator.get(prefixes, Materials.NaquadahEnriched, 1),
-                    isRich(prefixes) ? outputsRich : outputs
-                );
-            }
+            registryOreDictionaryRecipes(Materials.NaquadahEnriched, outputs, outputsRich);
         }
 
         // Naquadria Ore
@@ -192,15 +129,7 @@ public class OP_NormalProcessing {
                 GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 3), };
             ItemStack[] outputsRich = new ItemStack[] { GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 16),
                 GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 6), };
-            // registry raw ore item style
-            registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Naquadria, 1), outputs);
-            for (OrePrefixes prefixes : basicStoneTypes) {
-                if (GTOreDictUnificator.get(prefixes, Materials.Naquadria, 1) == null) continue;
-                registryOreProcessRecipe(
-                    GTOreDictUnificator.get(prefixes, Materials.Naquadria, 1),
-                    isRich(prefixes) ? outputsRich : outputs
-                );
-            }
+            registryOreDictionaryRecipes(Materials.Naquadria, outputs, outputsRich);
         }
 
         // Tinker Construct
@@ -242,32 +171,83 @@ public class OP_NormalProcessing {
     }
 
     /**
-     * Generate normal ore recipes
+     * Generate normal ore recipes from OreDictionary.
      *
-     * @param material The ore's Material.
-     * @param ID       The material ID.
+     * @param excludedMaterials The special Materials to exclude.
      */
-    public static void processOreRecipe(Materials material, int ID) {
-        if (GTOreDictUnificator.get(OrePrefixes.ore, material, 1) == null) return;
-        ItemStack[] outputs = getOutputs(material, false);
-        ItemStack[] outputsRich = getOutputs(material, true);
-
-        // registry normal stone ore
-        registryOreProcessRecipe(getModItem("gregtech", "gt.blockores", 1, ID), outputs);
-
-        // registry raw ore item style
-        registryOreProcessRecipe(GTOreDictUnificator.get(OrePrefixes.rawOre, material, 1), outputs);
-
-        // registry gt stone ore
-        for (OrePrefixes prefixes : basicStoneTypesExceptNormalStone) {
-            if (GTOreDictUnificator.get(prefixes, material, 1) == null) {
-                TwistSpaceTechnology.LOG.info("Failed to get ore: material=" + material + " , prefixes=" + prefixes);
-                continue;
+    private static void processOreDictionaryRecipes(Set<Materials> excludedMaterials) {
+        Map<Materials, ItemStack[]> outputs = new HashMap<>();
+        Map<Materials, ItemStack[]> outputsRich = new HashMap<>();
+        Set<Integer> registered = new HashSet<>();
+        for (String oreName : OreDictionary.getOreNames()) {
+            if (!isProcessableOreName(oreName)) continue;
+            for (ItemStack oreStack : OreDictionary.getOres(oreName)) {
+                ItemData association = GTOreDictUnificator.getAssociation(oreStack);
+                if (association == null || association.mMaterial == null || association.mMaterial.mMaterial == null)
+                    continue;
+                Materials material = association.mMaterial.mMaterial.mMaterialInto;
+                if (material == null || excludedMaterials.contains(material)) continue;
+                int stackId = GTUtility.stackToInt(oreStack);
+                if (!registered.add(stackId)) continue;
+                ItemStack[] normalOutputs = outputs.computeIfAbsent(material, key -> getOutputs(key, false));
+                if (normalOutputs.length == 0) continue;
+                ItemStack[] richOutputs = outputsRich.computeIfAbsent(material, key -> getOutputs(key, true));
+                registryOreProcessRecipe(
+                    GTUtility.copyAmountUnsafe(1, oreStack),
+                    isRichOre(association.mPrefix) ? richOutputs : normalOutputs);
             }
-            registryOreProcessRecipe(
-                GTOreDictUnificator.get(prefixes, material, 1),
-                isRich(prefixes) ? outputsRich : outputs);
         }
+    }
+
+    /**
+     * Register special ore recipes from OreDictionary.
+     *
+     * @param material    The ore's Material.
+     * @param outputs     The normal ore outputs.
+     * @param outputsRich The rich ore outputs.
+     */
+    private static void registryOreDictionaryRecipes(Materials material, ItemStack[] outputs, ItemStack[] outputsRich) {
+        Set<Integer> registered = new HashSet<>();
+        for (String oreName : OreDictionary.getOreNames()) {
+            if (!isProcessableOreName(oreName)) continue;
+            for (ItemStack oreStack : OreDictionary.getOres(oreName)) {
+                ItemData association = GTOreDictUnificator.getAssociation(oreStack);
+                if (association == null || association.mMaterial == null
+                    || association.mMaterial.mMaterial == null
+                    || association.mMaterial.mMaterial.mMaterialInto != material) continue;
+                if (!registered.add(GTUtility.stackToInt(oreStack))) continue;
+                registryOreProcessRecipe(
+                    GTUtility.copyAmountUnsafe(1, oreStack),
+                    isRichOre(association.mPrefix) ? outputsRich : outputs);
+            }
+        }
+    }
+
+    /**
+     * Check is this OreDictionary name a processable ore style.
+     *
+     * @param oreName The OreDictionary name to check.
+     * @return True is processable ore.
+     */
+    private static boolean isProcessableOreName(String oreName) {
+        return oreName != null
+            && (oreName.startsWith("rawOre") || oreName.startsWith("ore") && !oreName.startsWith("oreSmall")
+                && !oreName.startsWith("orePoor")
+                && !oreName.startsWith("oreNormal"));
+    }
+
+    /**
+     * Check is this OrePrefix a rich ore style.
+     *
+     * @param prefix The OrePrefix to check.
+     * @return True is rich ore.
+     */
+    private static boolean isRichOre(OrePrefixes prefix) {
+        if (prefix == OrePrefixes.oreRich) return true;
+        for (StoneType stoneType : StoneType.values()) {
+            if (stoneType.getPrefix() == prefix) return stoneType.isRich();
+        }
+        return false;
     }
 
     /**
@@ -287,11 +267,11 @@ public class OP_NormalProcessing {
         // check byproduct
         if (!material.mOreByProducts.isEmpty()) {
             // the basic output the material
-            outputs.add(getDustStack(material, 4));
+            addValidOutput(outputs, getDustStack(material, 4));
             if (material.mOreByProducts.size() == 1) {
                 for (Materials byproduct : material.mOreByProducts) {
                     if (byproduct == null) continue;
-                    outputs.add(getDustStack(byproduct, 3));
+                    addValidOutput(outputs, getDustStack(byproduct, 3));
                 }
             } else {
                 for (Materials byproduct : material.mOreByProducts) {
@@ -299,25 +279,25 @@ public class OP_NormalProcessing {
                         || byproduct == Materials.Endstone
                         || byproduct == Materials.Stone) continue;
 
-                    outputs.add(getDustStack(byproduct, 2));
+                    addValidOutput(outputs, getDustStack(byproduct, 2));
                 }
             }
 
         } else {
-            outputs.add(getDustStack(material, 8));
+            addValidOutput(outputs, getDustStack(material, 8));
         }
 
         // check gem style
         if (GTOreDictUnificator.get(OrePrefixes.gem, material, 1) != null) {
             if (GTOreDictUnificator.get(OrePrefixes.gemExquisite, material, 1) != null) {
                 // has gem style
-                outputs.add(GTOreDictUnificator.get(OrePrefixes.gemExquisite, material, 1));
-                outputs.add(GTOreDictUnificator.get(OrePrefixes.gemFlawless, material, 2));
-                outputs.add(GTOreDictUnificator.get(OrePrefixes.gem, material, 2));
+                addValidOutput(outputs, GTOreDictUnificator.get(OrePrefixes.gemExquisite, material, 1));
+                addValidOutput(outputs, GTOreDictUnificator.get(OrePrefixes.gemFlawless, material, 2));
+                addValidOutput(outputs, GTOreDictUnificator.get(OrePrefixes.gem, material, 2));
 
             } else {
                 // just normal gem
-                outputs.add(GTOreDictUnificator.get(OrePrefixes.gem, material, 4));
+                addValidOutput(outputs, GTOreDictUnificator.get(OrePrefixes.gem, material, 4));
             }
         }
 
@@ -330,6 +310,16 @@ public class OP_NormalProcessing {
         return outputs.toArray(new ItemStack[0]);
     }
 
+    /**
+     * Check is this ItemStack a valid output.
+     *
+     * @param outputs The output list to add to.
+     * @param output  The output ItemStack to check.
+     */
+    private static void addValidOutput(List<ItemStack> outputs, ItemStack output) {
+        if (output != null) outputs.add(output);
+    }
+
     public static void registryOreProcessRecipe(ItemStack input, ItemStack[] output) {
         if (input == null) return;
         TST_RecipeBuilder.builder()
@@ -340,15 +330,4 @@ public class OP_NormalProcessing {
             .duration(OreProcessRecipeDuration)
             .addTo(GTCMRecipe.OreProcessingRecipes);
     }
-
-    /**
-     * Check is this OrePrefix is rich ore style.
-     *
-     * @param prefixes The style to check.
-     * @return True is rich ore.
-     */
-    public static boolean isRich(OrePrefixes prefixes) {
-        return prefixes == OrePrefixes.oreNetherrack || prefixes == OrePrefixes.oreEndstone;
-    }
-
 }

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/machines/TST_OreProcessingFactory.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/machines/TST_OreProcessingFactory.java
@@ -33,7 +33,6 @@ import static tectech.thing.casing.TTCasingsContainer.sBlockCasingsTT;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -205,12 +204,14 @@ public class TST_OreProcessingFactory extends GTCM_MultiMachineBase<TST_OreProce
                             }
                         }
                     }
+                    break;
                 }
             }
             // If is gt ore but not in recipe map
             // Handle it specially
             if (hasNotFound) {
-                if (Objects.equals(items.getUnlocalizedName(), "gt.blockores")) {
+                if (items.getUnlocalizedName()
+                    .startsWith("gt.blockores")) {
                     TwistSpaceTechnology.LOG.info("OP system recipe has not write this material's: " + items);
                     outputs.add(items.copy());
                     items.stackSize = 0;
@@ -244,6 +245,7 @@ public class TST_OreProcessingFactory extends GTCM_MultiMachineBase<TST_OreProce
 
             boolean hasNotFound = true;
             for (GTRecipe recipe : recipeMap.getAllRecipes()) {
+                if (recipe.mInputs == null || recipe.mInputs.length < 1) continue;
                 if (GTUtility.areStacksEqual(recipe.mInputs[0], items)
                     && items.stackSize >= recipe.mInputs[0].stackSize) {
                     // found the recipe
@@ -286,12 +288,14 @@ public class TST_OreProcessingFactory extends GTCM_MultiMachineBase<TST_OreProce
                             }
                         }
                     }
+                    break;
                 }
             }
             // If is gt ore but not in recipe map
             // Handle it specially
             if (hasNotFound) {
-                if (Objects.equals(items.getUnlocalizedName(), "gt.blockores")) {
+                if (items.getUnlocalizedName()
+                    .startsWith("gt.blockores")) {
                     TwistSpaceTechnology.LOG.info("OP system recipe has not write this material's: " + items);
                     outputs.add(items.copy());
                     items.stackSize = 0;


### PR DESCRIPTION
 # PR 报告：修复 GT5 2.9.0beta 矿石处理厂矿辞不适配

## 关联 Issue

[#1265 - 0.8.11beta版矿石处理厂大部分矿物矿辞不适配2.9.0beta的矿物矿辞](https://github.com/Nxer/Twist-Space-Technology-Mod/issues/1265)

## GT 新旧矿石系统对比

GT5 从 2.8.x 升级到 2.9.0beta 对矿石系统进行了重构：

| 方面 | 旧版 (2.8.x / 5.09.51) | 新版 (2.9.0beta / 5.09.52) |
|------|------------------------|---------------------------|
| **矿石方块** | 单一 `gt.blockores`（TileEntity） | `gt.blockores2`~`gt.blockores7`（纯方块，无TE） |
| **石材类型** | 固定 7 种 GT 母岩，真实矿石信息保存在 TileEntity | [`StoneType`](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/api/enums/StoneType.java) 统一管理行星、冰和深板岩等母岩 |
| **OrePrefixes** | 仅 7 种基础石材前缀 | 40+ 种独立前缀（`oreMoon`, `oreMars`, `oreSethIce`, `oreDeepslate`...） |
| **矿石注册** | `BlockOresAbstract` 注册固定母岩的 OreDict 栈 | [`GTOreAdapter.init()`](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/common/ores/GTOreAdapter.java#L60-L116) 创建 6 个 [`GTBlockOre`](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/common/blocks/GTBlockOre.java) 实例 |
| **方块注册名** | `gt.blockores` | `gt.blockores2` ~ `gt.blockores7`（series 2~7） |
| **natural 状态** | 保存在 TileEntity 的 `mNatural`，不属于 ItemStack metadata | 编码进 metadata 的 `+8000`，世界生成时使用；OreDict 和机器产物通常为非 natural 栈 |
| **rawOre 矿辞名** | GT 已使用 `rawOre{Name}`，部分 GT++ 旧代码仍有 `oreRaw{Name}` 字符串 | 新矿石系统统一使用 `rawOre{Name}` |
| **OreDict 注册** | 旧版手动注册 | [`GTBlockOre` 构造函数](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/common/blocks/GTBlockOre.java#L82-L101) 遍历 `matId 0~999` 调用 [`GTOreDictUnificator.set()`](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/api/util/GTOreDictUnificator.java#L75-L93) |

新版同时将 BartWorks/GT++ 矿脉接入统一矿石系统，并增加 GC/GalaxySpace 母岩与气体冰矿石。TST 原实现依赖旧 `gt.blockores` 和固定前缀，因此无法覆盖新版实际注册的矿石栈。

## 修改内容

### 配方输入生成

[`OP_NormalProcessing.java`](https://github.com/Nxer/Twist-Space-Technology-Mod/blob/master/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/logic/OP_NormalProcessing.java) 参照新版 GT [`MTEIntegratedOreFactory.initHash()`](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/common/tileentities/machines/multi/MTEIntegratedOreFactory.java#L153-L170)：遍历 `OreDictionary.getOreNames()`，读取 `ore*`、`rawOre*` 下每个实际 ItemStack，并按 `GTUtility.stackToInt()` 对 Item 与 metadata 去重。

TST 保留原有“一步输出最终产物”的产量模型，因此排除 `oreSmall*`、`orePoor*` 和 `oreNormal*`，避免把小矿石、贫矿石直接套用普通大矿产量。`oreRich*` 与母岩前缀仍根据 GT 前缀/`StoneType.isRich()` 使用富矿产物。

材料通过 `GTOreDictUnificator.getAssociation(stack)` 读取并规范化到 `mMaterialInto`。GT、BartWorks、GT++ 只要把实际矿石栈注册进 OreDictionary，即可被同一流程覆盖。

只注册 OreDictionary 中真实存在的栈。`addValidOutput()` 同时过滤缺失粉尘/副产物，避免配方加载阶段 NPE。铈、钐和硅岩系列保留特殊输出，但输入改用同一 OreDictionary 扫描。

### 机器处理

[`TST_OreProcessingFactory.java`](https://github.com/Nxer/Twist-Space-Technology-Mod/blob/master/src/main/java/com/Nxer/TwistSpaceTechnology/system/OreProcess/machines/TST_OreProcessingFactory.java)：

```diff
- Objects.equals(items.getUnlocalizedName(), "gt.blockores")
+ items.getUnlocalizedName().startsWith("gt.blockores")
```

- 前缀判断覆盖 `gt.blockores2` ~ `gt.blockores7`；该分支仅处理未命中 TST 配方的 GT 矿石并原样输出。
- 无线与普通模式跳过无有效输入的配方。
- 命中后立即 `break`，避免重复配方继续处理已扣减输入并产生 `parallel == 0`。

## 配方数量与性能

扫描发生在 TST 配方加载阶段；运行时仍使用 TST 的一步终产物 RecipeMap，不复刻 GT IOF 的多阶段加工链。

Closes #1265
