### PR TITLE
Fix issue#1287

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_CircuitImprintHatch.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/TST_CircuitImprintHatch.java
@@ -131,9 +131,7 @@ public class TST_CircuitImprintHatch extends MTEHatch implements IAddUIWidgets {
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
-        if (aNBT.getByte("mCircuitUpdated") != 1) {
-            refreshImprint();
-        }
+        refreshImprint();
     }
 
     @Override
@@ -143,8 +141,8 @@ public class TST_CircuitImprintHatch extends MTEHatch implements IAddUIWidgets {
     }
 
     @Override
-    public void setInventorySlotContents(int aIndex, ItemStack aStack) {
-        super.setInventorySlotContents(aIndex, aStack);
+    public void onContentsChanged(int aIndex) {
+        super.onContentsChanged(aIndex);
         refreshImprint();
     }
 


### PR DESCRIPTION
我尝试在压印仓里放入了压印电路但是不工作,但是我重进后又正常了,反之亦然,因此是缓存有问题.检查后发现放入压印电路时使用 getInventoryHandler(),但不会触发 setInventorySlotContents,一同的 refreshImprint() 没有被调用，缓存也就没被刷新,因此这里换成能触发的 onContentsChanged.